### PR TITLE
Fixing missing dependency preventing it to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ setup(
     install_requires=[
         "torch",
         "packaging",
-        "buildtools"
+        "buildtools",
         "ninja",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,7 @@ setup(
     install_requires=[
         "torch",
         "packaging",
+        "buildtools"
         "ninja",
     ],
 )


### PR DESCRIPTION
buildtools is actually required for this to be installed. In environments that don't have buildtools, following error is encountered : 
https://github.com/Dao-AILab/causal-conv1d/issues/2#issuecomment-1845562938