### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,10 @@ if not SKIP_CUDA_BUILD:
     cc_flag.append("arch=compute_70,code=sm_70")
     cc_flag.append("-gencode")
     cc_flag.append("arch=compute_80,code=sm_80")
-    if bare_metal_version >= Version("11.8"):
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_90,code=sm_90")
+    if CUDA_HOME is not None:
+        if bare_metal_version >= Version("11.8"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_90,code=sm_90")
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
the variable `bare_metal_version` is unbound and setup fails with an unhelpful error message. now it fails with much more pleasant `OSError: CUDA_HOME environment variable is not set. Please set it to your CUDA install root.`