### PR TITLE
Change interface to  causal_conv1d_update for continuous batching

### DIFF
--- a/causal_conv1d/causal_conv1d_interface.py
+++ b/causal_conv1d/causal_conv1d_interface.py
@@ -172,7 +172,7 @@ def causal_conv1d_ref(
     return out if not return_final_states else (out, final_states_out)
 
 
-def causal_conv1d_update(x, conv_state, weight, bias=None, activation=None, cache_seqlens=None):
+def causal_conv1d_update(x, conv_state, weight, bias=None, activation=None, cache_seqlens=None, conv_state_indices=None):
     """
     x: (batch, dim) or (batch, dim, seqlen)
     conv_state: (batch, dim, state_len), where state_len >= width - 1
@@ -182,6 +182,10 @@ def causal_conv1d_update(x, conv_state, weight, bias=None, activation=None, cach
         If not None, the conv_state is treated as a circular buffer.
         The conv_state will be updated by copying x to the conv_state starting at the index
         @cache_seqlens % state_len.
+    conv_state_indices: (batch,), dtype int32
+        If None, the conv_state is a larger tensor along the batch dim, 
+        and we are selecting the batch coords specified by conv_state_indices.
+        Useful for a continuous batching scenario.
 
     out: (batch, dim) or (batch, dim, seqlen)
     """
@@ -192,7 +196,7 @@ def causal_conv1d_update(x, conv_state, weight, bias=None, activation=None, cach
     if unsqueeze:
         x = x.unsqueeze(-1)
     out = causal_conv1d_cuda.causal_conv1d_update(
-        x, conv_state, weight, bias, activation, cache_seqlens
+        x, conv_state, weight, bias, activation, cache_seqlens, conv_state_indices
     )
     if unsqueeze:
         out = out.squeeze(-1)

--- a/csrc/causal_conv1d.h
+++ b/csrc/causal_conv1d.h
@@ -35,6 +35,10 @@ struct ConvParamsBase {
     void *__restrict__ conv_state_ptr;
     int32_t *__restrict__ cache_seqlens;
 
+    // Only used if the elements of the batch are gathered from a larger buffer,
+    // which may happen for continuous batching.
+    int32_t *__restrict__ conv_state_indices_ptr;
+
     void *__restrict__ seq_idx_ptr;
 
     // No __restrict__ since initial_states could be the same as final_states.

--- a/csrc/causal_conv1d_update.cu
+++ b/csrc/causal_conv1d_update.cu
@@ -38,8 +38,8 @@ void causal_conv1d_update_kernel(ConvParamsBase params) {
 
     // If params.conv_state_batch_indices is set, then the conv state is gathered from the conv state tensor
     // along the batch axis. Otherwise, the conv state coordinate is the same as the batch id.
-    const int conv_state_batch_coord = params.conv_state_indices_ptr == nullptr 
-        ? batch_id 
+    const int conv_state_batch_coord = params.conv_state_indices_ptr == nullptr
+        ? batch_id
         : params.conv_state_indices_ptr[batch_id];
     input_t *conv_state = reinterpret_cast<input_t *>(params.conv_state_ptr) 
         + conv_state_batch_coord * params.conv_state_batch_stride

--- a/csrc/causal_conv1d_update.cu
+++ b/csrc/causal_conv1d_update.cu
@@ -35,7 +35,14 @@ void causal_conv1d_update_kernel(ConvParamsBase params) {
 
     input_t *x = reinterpret_cast<input_t *>(params.x_ptr) + batch_id * params.x_batch_stride
         + channel_id * params.x_c_stride;
-    input_t *conv_state = reinterpret_cast<input_t *>(params.conv_state_ptr) + batch_id * params.conv_state_batch_stride
+
+    // If params.conv_state_batch_indices is set, then the conv state is gathered from the conv state tensor
+    // along the batch axis. Otherwise, the conv state coordinate is the same as the batch id.
+    const int conv_state_batch_coord = params.conv_state_indices_ptr == nullptr 
+        ? batch_id 
+        : params.conv_state_indices_ptr[batch_id];
+    input_t *conv_state = reinterpret_cast<input_t *>(params.conv_state_ptr) 
+        + conv_state_batch_coord * params.conv_state_batch_stride
         + channel_id * params.conv_state_c_stride;
     weight_t *weight = reinterpret_cast<weight_t *>(params.weight_ptr) + channel_id * params.weight_c_stride;
     input_t *out = reinterpret_cast<input_t *>(params.out_ptr) + batch_id * params.out_batch_stride


### PR DESCRIPTION
Currently, the conv_state passed to `causal_conv1d_update` must be represented a single tensor. This leads to difficulties with the management of the state for Jamba models in vLLM. This is because with continuous batching, the items in the current batch have arrived at different times, and their associated state is therefore allocated at different times and therefore likely different places.  

The initial Jamba support in vLLM https://github.com/vllm-project/vllm/pull/4115 dealt with this by allocating two buffers and copied the state for the current batch into a contiguous tensor. A subsequent PR https://github.com/vllm-project/vllm/pull/6739 added some bookkeeping to remove that extra memory and to reduce overhead from copying the state.

This PR adds the ability to pass a list of indices to `causal_conv_1d_update`, so each element in the batch can come from a different location in a larger conv_state tensor.