### PR TITLE
Move ninja from install_requires to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -362,6 +362,8 @@ setup(
     install_requires=[
         "torch",
         "packaging",
+    ],
+    setup_requires=[
         "ninja",
     ],
 )


### PR DESCRIPTION
Set `ninja` as build time dependency rather than runtime dependency.

Xref https://github.com/conda-forge/staged-recipes/pull/29821/files#r2066577425 where we're trying to package `causal-conv1d` on conda-forge, and would like the setup.py metadata to be correct so that running `pip check` would work.

Similar case to https://github.com/Dao-AILab/flash-attention/pull/937.