### PR TITLE
Added support for RTX 50 Series

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,9 @@ if not SKIP_CUDA_BUILD:
         if bare_metal_version >= Version("12.8"):
             cc_flag.append("-gencode")
             cc_flag.append("arch=compute_100,code=sm_100")
+        if bare_metal_version >= Version("12.9"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_121,code=sm_121")            
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
[Requires CUDA Toolkit 12.9 version. ](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)

>  CUDA Toolkit 12.9 adds compiler target support for SM architecture 10.3 (sm_103, sm_103f, sm_103a) and 12.1 (sm_121), enabling development for the latest GPU architectures with specific optimizations for each variant.

Compiled successfully with RTX 5090 under: nvcr.io/nvidia/pytorch:25.04-py3