### PR TITLE
full CUDA Support for Blackwell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,15 @@ if not SKIP_CUDA_BUILD:
         if bare_metal_version >= Version("12.8"):
             cc_flag.append("-gencode")
             cc_flag.append("arch=compute_100,code=sm_100")
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_101,code=sm_101")
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_120,code=sm_120")
+        if bare_metal_version >= Version("12.9"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_103,code=sm_103")
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_121,code=sm_121")
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
this PR enabled full cuda support with the correct compute levels to leverage all kernels provided by the toolkit, CUDA 12.8 adds: 100, 101 and 120 (see https://docs.nvidia.com/cuda/archive/12.8.1/cuda-toolkit-release-notes/index.html ) and for CUDA 12.9 adds 103, 121 see https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html 