### PR TITLE
build(fix): pypi sdist installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include csrc/*.h
+include csrc/*.cu
+recursive-include third_party *
+README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
PyPi installs are failing if no pre-built wheel is found. This is because the sdist package misses csrc files. This PR includes those into the packaged wheel so that users can integrate causal-conv1d as dependency into their pypi wheels.