### PR TITLE
build: Include all CSRC files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include csrc/*.h
-include csrc/*.cu
+recursive-include csrc *
 recursive-include third_party *
 README.md


### PR DESCRIPTION
Hey @tridao, in my prev. PR I overlooked a small detail. Not all CSRC files where included, causing the build still to fail. Apologies for that

(the mamba-pr was already smarter in the choice of included files, so that PR should be fine)