### PR TITLE
Fix device guards for newer torch

### DIFF
--- a/csrc/causal_conv1d.cpp
+++ b/csrc/causal_conv1d.cpp
@@ -2,7 +2,13 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
+#include <torch/extension.h>
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
+#include <c10/core/DeviceGuard.h>
+#else
 #include <c10/cuda/CUDAGuard.h>
+#endif
+
 #include <c10/cuda/CUDAStream.h>
 #include <torch/python.h>
 #include <vector>
@@ -221,7 +227,11 @@ causal_conv1d_fwd(const at::Tensor &x,
     }
 
     // Otherwise the kernel will be launched from cuda:0 device
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
+    c10::DeviceGuard device_guard(x.device());
+#else
     at::cuda::CUDAGuard device_guard{x.device()};
+#endif
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_fwd", [&] {
         DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_fwd", [&] {
@@ -304,8 +314,12 @@ causal_conv1d_bwd(const at::Tensor &x,
     if (is_channel_last) { TORCH_CHECK(dx.stride(1) == 1); }
 
     // Otherwise the kernel will be launched from cuda:0 device
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
+    c10::Device device = x.device();
+    c10::DeviceGuard device_guard(device);
+#else
     at::cuda::CUDAGuard device_guard{x.device()};
-
+#endif
     ConvParamsBwd params;
     set_conv_params_bwd(params, batch_size, dim, seqlen, width,
                         x, weight, bias_.has_value() ? bias_.value().data_ptr() : nullptr,
@@ -450,7 +464,12 @@ causal_conv1d_update(const at::Tensor &x,
     }
 
     // Otherwise the kernel will be launched from cuda:0 device
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
+    c10::Device device = x.device();
+    c10::DeviceGuard device_guard(device);
+#else
     at::cuda::CUDAGuard device_guard{x.device()};
+#endif
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_update", [&] {
         DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_update", [&] {


### PR DESCRIPTION
When using newer torch (2.6+), I'm trying to import the cc1d cuda extension:

```
import causal_conv1d_cuda
```

which gives:

```
ImportError: /workspace/cca_helper_kernels/causal-conv1d/causal_conv1d_cuda.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN3c104cuda9SetDeviceEab
```


I tried flipping `D_GLIBCXX_USE_CXX11_ABI` on and off, did a fresh source build, etc. I instead sidestepped the mangled symbol entirely by using `DeviceGuard` for newer torch, which torch devs recommend moving to anyways.

Let me know if you want further testing, have other alternatives, etc. I think it's best overall to go this route.