### PR TITLE
Support padding tokens

### DIFF
--- a/csrc/causal_conv1d_fwd.cu
+++ b/csrc/causal_conv1d_fwd.cu
@@ -306,13 +306,6 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
     }
     int seq_idx_thread[kWidth - 1 + kLPerThread];
     if constexpr (kHasSeqIdx) {
-        // For padding tokens (seq_idx < 0), we skip the computation and set the output to 0.
-        if constexpr (kHasSeqIdx) {
-            if (seq_idx_cur < 0) {
-                out_vals[i] = 0.f;
-                continue;
-            }
-        }
         #pragma unroll
         for (int i = 0; i < kWidth - 1 + kLPerThread; ++i) {
             seq_idx_thread[i] = chunk_l_id * kChunkSizeL + col_idx * kLPerThread + i - (kWidth - 1) >= 0 ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)] : -1;
@@ -324,6 +317,11 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
     for (int i = 0; i < kLPerThread; ++i) {
         out_vals[i] = bias_val;
         const int seq_idx_cur = !kHasSeqIdx ? 0 : seq_idx_thread[i + kWidth - 1];
+        // For padding tokens (seq_idx < 0), we skip the computation and set the output to 0.
+        if (seq_idx_cur < 0) {
+            out_vals[i] = 0.f;
+            continue;
+        }
         #pragma unroll
         for (int w = 0; w < kWidth; ++w) {
             if constexpr (!kHasSeqIdx) {

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -202,6 +202,94 @@ def test_causal_conv1d_update_with_batch_gather(dim, width, seqlen, has_cache_se
 
 @pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
 # @pytest.mark.parametrize('itype', [torch.float16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+# @pytest.mark.parametrize('silu_activation', [True])
+@pytest.mark.parametrize("has_bias", [False, True])
+# @pytest.mark.parametrize('has_bias', [True])
+@pytest.mark.parametrize("has_cache_seqlens", [False])#, True])
+# @pytest.mark.parametrize('has_cache_seqlens', [True])
+@pytest.mark.parametrize("seqlen", [1, 4, 5])
+# @pytest.mark.parametrize('seqlen', [4])
+@pytest.mark.parametrize("width", [2, 3, 4])
+# @pytest.mark.parametrize('width', [4])
+@pytest.mark.parametrize("dim", [2048, 2048 + 16, 4096])
+# @pytest.mark.parametrize("dim", [2048])
+def test_causal_conv1d_update_with_padding(dim, width, seqlen, has_cache_seqlens, has_bias, silu_activation, itype):
+    device = "cuda"
+    rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    # set seed
+    torch.random.manual_seed(0)
+    batch = 64
+    x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(-1, -2)
+    state_len = torch.randint(width - 1, width + 10, (1,)).item()
+
+    total_entries = 10 * batch
+    conv_state = torch.randn(total_entries, state_len, dim, device=device, dtype=itype).transpose(-1, -2)
+
+    # Introduce padding by setting some indices to -1
+    num_valid_requests = batch // 2
+    num_padded_requests = batch - num_valid_requests
+
+    valid_indices = torch.randperm(total_entries)[:num_valid_requests].to(device=device)
+    padded_indices = torch.full((num_padded_requests,), -1, device=device)
+
+    # Shuffle the valid and padded indices together
+    combined_indices = torch.cat([valid_indices, padded_indices])
+    perm = torch.randperm(batch, device=device)
+    conv_state_indices = combined_indices[perm].to(dtype=torch.int32)
+
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32)
+    bias = torch.randn(dim, device=device, dtype=torch.float32) if has_bias else None
+
+    activation = "silu" if silu_activation else None
+
+    has_cache_seqlens = False
+    cache_seqlens = None
+    #cache_seqlens = (torch.randint(0, 1024, (batch,), dtype=torch.int32, device=device)
+    #                 if has_cache_seqlens else None)
+
+    # Clone original state for later comparison
+    conv_state_original = conv_state.clone()
+
+    # Run the main function with padded indices
+    out = causal_conv1d_update(x, conv_state, weight, bias, activation=activation,
+                               cache_seqlens=cache_seqlens, conv_state_indices=conv_state_indices)
+
+    # Manually compute the reference output and expected final state
+    out_ref = torch.zeros_like(out)
+    conv_state_expected = conv_state_original.clone()
+    valid_mask = conv_state_indices != -1
+
+    # Only compute the reference for the valid (non-padded) requests
+    if num_valid_requests > 0:
+        x_valid = x[valid_mask]
+        conv_state_indices_valid = conv_state_indices[valid_mask]
+        # This will be modified in-place by the ref function to get the expected updated state
+        conv_state_valid_updated = conv_state_original[conv_state_indices_valid, :].detach().clone()
+        cache_seqlens_valid = cache_seqlens[valid_mask] if has_cache_seqlens else None
+
+        out_ref_valid = causal_conv1d_update_ref(x_valid, conv_state_valid_updated, weight, bias,
+                                                 activation=activation, cache_seqlens=cache_seqlens_valid)
+        out_ref[valid_mask] = out_ref_valid
+        # Place the updated states into our expected full state tensor
+        conv_state_expected[conv_state_indices_valid] = conv_state_valid_updated
+
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+
+    # The output for padded tokens should be exactly zero
+    assert torch.all(out[~valid_mask] == 0)
+    assert torch.allclose(out[valid_mask], out_ref[valid_mask], rtol=rtol, atol=atol)
+
+    # Check that conv_state was updated correctly for valid tokens and untouched otherwise
+    assert torch.equal(conv_state, conv_state_expected)
+
+
+@pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
+# @pytest.mark.parametrize('itype', [torch.float16])
 @pytest.mark.parametrize("dim", [2048, 2048 + 16, 4096])
 # @pytest.mark.parametrize("dim", [2048])
 def test_causal_conv1d_get_states(dim, itype):
@@ -349,3 +437,88 @@ def test_causal_conv1d_varlen(dim, seqlen, width, has_bias, silu_activation, ity
     assert torch.allclose(weight.grad, weight_ref.grad, rtol=rtolw, atol=atolw)
     if has_bias:
         assert torch.allclose(bias.grad, bias_ref.grad, rtol=rtolw, atol=atolw)
+
+@pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
+# @pytest.mark.parametrize('itype', [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+# @pytest.mark.parametrize('silu_activation', [True])
+@pytest.mark.parametrize("has_bias", [False, True])
+# @pytest.mark.parametrize('has_bias', [True])
+@pytest.mark.parametrize("width", [2, 3, 4])
+# @pytest.mark.parametrize('width', [4])
+@pytest.mark.parametrize(
+    "seqlen", [128, 256, 512, 1024]
+)
+# @pytest.mark.parametrize('seqlen', [128])
+@pytest.mark.parametrize('dim', [64, 4096 + 32])
+# @pytest.mark.parametrize('dim', [64])
+def test_causal_conv1d_varlen_padding(dim, seqlen, width, has_bias, silu_activation, itype):
+    device = "cuda"
+    rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    rtolw, atolw = (1e-3, 1e-3)
+    # set seed
+    torch.random.manual_seed(seqlen + dim + width)
+    batch = 3
+    max_seqlen = seqlen
+
+    # Generate sequences of varying lengths for each batch item, some shorter than max_seqlen
+    true_seqlens = [torch.randint(max_seqlen // 2, max_seqlen + 1, (1,)).item() for _ in range(batch)]
+
+    seqlens = []
+    for b in range(batch):
+        # Within each true sequence, we can have multiple sub-sequences
+        nsplits = torch.randint(1, 4, (1,)).item()
+        eos_pos = torch.randperm(true_seqlens[b] - 1)[:nsplits].sort().values
+        sl = torch.diff(torch.cat([torch.tensor([-1]), eos_pos, torch.tensor([true_seqlens[b] - 1])])).tolist()
+        seqlens.append(sl)
+        assert sum(sl) == true_seqlens[b]
+        assert all(s > 0 for s in sl)
+
+    # Only support channel_last
+    x = rearrange(
+        torch.randn(batch, max_seqlen, 4096 + dim + 64, device=device, dtype=itype)[:, :, 4096:4096 + dim], "b s d -> b d s"
+    ).requires_grad_()
+
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32, requires_grad=True)
+    bias = torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True) if has_bias else None
+
+    # Construct seq_idx with -1 for padding
+    seq_idx_list = []
+    conv_batch_idx_counter = 0
+    for b in range(batch):
+        seq_idx_b = []
+        for s in seqlens[b]:
+            seq_idx_b.append(torch.full((s,), conv_batch_idx_counter, dtype=torch.int32, device=device))
+            conv_batch_idx_counter += 1
+        seq_idx_b = torch.cat(seq_idx_b, dim=0)
+        # Add padding indices
+        padding_len = max_seqlen - true_seqlens[b]
+        assert padding_len > 0
+        seq_idx_b = torch.cat([seq_idx_b, torch.full((padding_len,), -1, dtype=torch.int32, device=device)], dim=0)
+        seq_idx_list.append(seq_idx_b)
+    seq_idx = torch.stack(seq_idx_list, dim=0)
+
+    x_ref = x.detach().clone()
+    weight_ref = weight.detach().clone()
+    bias_ref = bias.detach().clone() if bias is not None else None
+    activation = "silu" if silu_activation else None
+
+    # Run forward pass with padding
+    out = causal_conv1d_fn(x, weight, bias, seq_idx=seq_idx, activation=activation)
+
+    # Manual reference calculation
+    out_ref = torch.zeros_like(x_ref)
+    for b in range(batch):
+        out_ref_b = []
+        # We only process the true sequence part
+        x_b_unpadded = x_ref[[b], :, :true_seqlens[b]]
+        # Split into sub-sequences
+        for x_s in torch.split(x_b_unpadded, seqlens[b], dim=2):
+            out_ref_b.append(causal_conv1d_ref(x_s, weight_ref, bias_ref, activation=activation))
+        out_ref[b, :, :true_seqlens[b]] = torch.cat(out_ref_b, dim=2)
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)


### PR DESCRIPTION
Skips padding tokens in `causal_conv1d_update_kernel` and `causal_conv1d_channellast_fwd_kernel`, where padding tokens are defined as having `seq_idx < 0` or `conv_state_indices < 0`. This is to ensure shapes do not have to change when using CUDA graphs with padding.