### PR TITLE
Port to Python and libtorch stable ABI

### DIFF
--- a/causal_conv1d/cpp_functions.py
+++ b/causal_conv1d/cpp_functions.py
@@ -1,11 +1,21 @@
 # Copyright (c) 2024, Tri Dao.
 
+import os
+
 import torch
 
 import causal_conv1d_cuda
 
 
 LIBRARY_NAME = "DaoAILab"
+
+DETERMINISTIC = os.getenv("CAUSAL_CONV1D_DETERMINISTIC")
+if DETERMINISTIC == "1":
+    DETERMINISTIC = True
+elif DETERMINISTIC == "0":
+    DETERMINISTIC = False
+else:
+    DETERMINISTIC = torch.are_deterministic_algorithms_enabled()
 
 
 @torch.library.custom_op(f"{LIBRARY_NAME}::_causal_conv1d_fwd_cpp", mutates_args={"out", "final_states_out"})
@@ -19,7 +29,7 @@ def _causal_conv1d_fwd_cpp(
     final_states_out: torch.Tensor | None,
     silu_activation: bool,
 ) -> None:
-    causal_conv1d_cuda.causal_conv1d_fwd(
+    torch.ops.causal_conv1d_cuda.causal_conv1d_fwd(
         x,
         weight,
         bias,
@@ -52,7 +62,7 @@ def _causal_conv1d_bwd_cpp(
     dinitial_states: torch.Tensor,
     silu_activation: bool,
 ) -> None:
-    causal_conv1d_cuda.causal_conv1d_bwd(
+    torch.ops.causal_conv1d_cuda.causal_conv1d_bwd(
         x,
         weight,
         bias,
@@ -65,6 +75,7 @@ def _causal_conv1d_bwd_cpp(
         dbias,
         dinitial_states,
         silu_activation,
+        DETERMINISTIC,
     )
 
 
@@ -79,7 +90,7 @@ def _causal_conv1d_update_cpp(
     cache_seqlens: torch.Tensor | None,
     conv_state_indices: torch.Tensor | None,
 ) -> None:
-    causal_conv1d_cuda.causal_conv1d_update(
+    torch.ops.causal_conv1d_cuda.causal_conv1d_update(
         x,
         conv_state,
         weight,

--- a/csrc/causal_conv1d.cpp
+++ b/csrc/causal_conv1d.cpp
@@ -2,60 +2,58 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
-#include <torch/extension.h>
-#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
-#include <c10/core/DeviceGuard.h>
-#else
-#include <c10/cuda/CUDAGuard.h>
-#endif
+#include <Python.h>
 
-#include <c10/cuda/CUDAStream.h>
-#include <ATen/Context.h>
-#include <torch/python.h>
-#include <vector>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
+
 #include <cstdlib>
+#include <cstring>
+#include <optional>
 
 #include "causal_conv1d.h"
 
-namespace {
-bool use_deterministic_mode() {
-    const char* env = std::getenv("CAUSAL_CONV1D_DETERMINISTIC");
-    if (env) {
-        if (*env == '1') return true;
-        if (*env == '0') return false;
-    }
-    return at::globalContext().deterministicAlgorithms();
-}
-}
+using torch::stable::Tensor;
+using torch::headeronly::ScalarType;
 
-#define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
+#define CHECK_SHAPE(x, ...) STD_TORCH_CHECK((x).sizes().equals({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
 
 #define DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(ITYPE, NAME, ...)                    \
-    if (ITYPE == at::ScalarType::Half) {                                            \
-        using input_t = at::Half;                                                   \
+    if (ITYPE == ScalarType::Half) {                                                \
+        using input_t = torch::headeronly::Half;                                    \
         __VA_ARGS__();                                                              \
-    } else if (ITYPE == at::ScalarType::BFloat16) {                                 \
-        using input_t = at::BFloat16;                                               \
+    } else if (ITYPE == ScalarType::BFloat16) {                                     \
+        using input_t = torch::headeronly::BFloat16;                                \
         __VA_ARGS__();                                                              \
-    } else if (ITYPE == at::ScalarType::Float)  {                                   \
+    } else if (ITYPE == ScalarType::Float)  {                                       \
         using input_t = float;                                                      \
         __VA_ARGS__();                                                              \
     } else {                                                                        \
-        AT_ERROR(#NAME, " not implemented for input type '", toString(ITYPE), "'"); \
+        STD_TORCH_CHECK(false, #NAME, " not implemented for input type '", torch::headeronly::toString(ITYPE), "'"); \
     }
 
 #define DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(WTYPE, NAME, ...)                     \
-    if (WTYPE == at::ScalarType::Half) {                                             \
-        using weight_t = at::Half;                                                   \
+    if (WTYPE == ScalarType::Half) {                                                 \
+        using weight_t = torch::headeronly::Half;                                    \
         __VA_ARGS__();                                                               \
-    } else if (WTYPE == at::ScalarType::BFloat16) {                                  \
-        using weight_t = at::BFloat16;                                               \
+    } else if (WTYPE == ScalarType::BFloat16) {                                      \
+        using weight_t = torch::headeronly::BFloat16;                                \
         __VA_ARGS__();                                                               \
-    } else if (WTYPE == at::ScalarType::Float)  {                                    \
+    } else if (WTYPE == ScalarType::Float)  {                                        \
         using weight_t = float;                                                      \
         __VA_ARGS__();                                                               \
     } else {                                                                         \
-        AT_ERROR(#NAME, " not implemented for weight type '", toString(WTYPE), "'"); \
+        STD_TORCH_CHECK(false, #NAME, " not implemented for weight type '", torch::headeronly::toString(WTYPE), "'"); \
     }
 
 template<typename input_t, typename weight_t>
@@ -71,6 +69,36 @@ void causal_conv1d_channellast_bwd_cuda(ConvParamsBwd &params, cudaStream_t stre
 template<typename input_t, typename weight_t>
 void causal_conv1d_update_cuda(ConvParamsBase &params, cudaStream_t stream);
 
+namespace {
+
+cudaStream_t get_cuda_stream(const Tensor &tensor) {
+    void* stream_ptr = nullptr;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(tensor.get_device_index(), &stream_ptr));
+    return static_cast<cudaStream_t>(stream_ptr);
+}
+
+torch::stable::Tensor sum_along_dims(const Tensor &tensor,
+                                     std::initializer_list<int64_t> dims) {
+    auto dims_ref = torch::headeronly::IntHeaderOnlyArrayRef(dims);
+    return torch::stable::sum(tensor,
+                              std::optional<torch::headeronly::IntHeaderOnlyArrayRef>(dims_ref),
+                              false,
+                              std::nullopt);
+}
+
+void add_tensor_in_place(Tensor tensor, const Tensor &other) {
+    auto updated = torch::stable::subtract(tensor, other, -1.0);
+    torch::stable::copy_(tensor, updated);
+}
+
+void add_workspace_sum_in_place(Tensor tensor,
+                                const Tensor &workspace,
+                                std::initializer_list<int64_t> dims) {
+    add_tensor_in_place(tensor, sum_along_dims(workspace, dims));
+}
+
+}
+
 void set_conv_params_fwd(ConvParamsBase &params,
                          // sizes
                          const size_t batch,
@@ -78,9 +106,9 @@ void set_conv_params_fwd(ConvParamsBase &params,
                          const size_t seqlen,
                          const size_t width,
                          // device pointers
-                         const at::Tensor x,
-                         const at::Tensor weight,
-                         const at::Tensor out,
+                         const Tensor &x,
+                         const Tensor &weight,
+                         const Tensor &out,
                          void* bias_ptr,
                          bool silu_activation) {
 
@@ -110,7 +138,6 @@ void set_conv_params_fwd(ConvParamsBase &params,
     params.out_l_stride = out.stride(-1);
 }
 
-
 void set_conv_params_bwd(ConvParamsBwd &params,
                          // sizes
                          const size_t batch,
@@ -118,12 +145,12 @@ void set_conv_params_bwd(ConvParamsBwd &params,
                          const size_t seqlen,
                          const size_t width,
                          // device pointers
-                         const at::Tensor x,
-                         const at::Tensor weight,
+                         const Tensor &x,
+                         const Tensor &weight,
                          void* bias_ptr,
-                         const at::Tensor dout,
-                         const at::Tensor dx,
-                         const at::Tensor dweight,
+                         const Tensor &dout,
+                         const Tensor &dx,
+                         const Tensor &dweight,
                          void* dbias_ptr,
                          bool silu_activation) {
     // Pass in "dout" instead of "out", we're not gonna use "out" at all.
@@ -147,21 +174,21 @@ void set_conv_params_bwd(ConvParamsBwd &params,
 }
 
 void
-causal_conv1d_fwd(const at::Tensor &x,
-                  const at::Tensor &weight,
-                  const c10::optional<at::Tensor> &bias_,
-                  const c10::optional<at::Tensor> &seq_idx_,
-                  const c10::optional<at::Tensor> &initial_states_,
-                  at::Tensor &out,
-                  c10::optional<at::Tensor> &final_states_out_,
+causal_conv1d_fwd(const Tensor &x,
+                  const Tensor &weight,
+                  const std::optional<Tensor> &bias_,
+                  const std::optional<Tensor> &seq_idx_,
+                  const std::optional<Tensor> &initial_states_,
+                  Tensor out,
+                  std::optional<Tensor> final_states_out_,
                   bool silu_activation) {
     auto input_type = x.scalar_type();
     auto weight_type = weight.scalar_type();
-    TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
-    TORCH_CHECK(weight_type == at::ScalarType::Float || weight_type == at::ScalarType::Half || weight_type == at::ScalarType::BFloat16);
+    STD_TORCH_CHECK(input_type == ScalarType::Float || input_type == ScalarType::Half || input_type == ScalarType::BFloat16);
+    STD_TORCH_CHECK(weight_type == ScalarType::Float || weight_type == ScalarType::Half || weight_type == ScalarType::BFloat16);
 
-    TORCH_CHECK(x.is_cuda());
-    TORCH_CHECK(weight.is_cuda());
+    STD_TORCH_CHECK(x.is_cuda());
+    STD_TORCH_CHECK(weight.is_cuda());
 
     const auto sizes = x.sizes();
     const int batch_size = sizes[0];
@@ -172,29 +199,29 @@ causal_conv1d_fwd(const at::Tensor &x,
     CHECK_SHAPE(x, batch_size, dim, seqlen);
     CHECK_SHAPE(weight, dim, width);
 
-    TORCH_CHECK(x.stride(2) == 1 || x.stride(1) == 1);
+    STD_TORCH_CHECK(x.stride(2) == 1 || x.stride(1) == 1);
     const bool is_channel_last = x.stride(1) == 1 && x.stride(2) > 1;
 
     if (is_channel_last) {
-        TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
-        TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
+        STD_TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
+        STD_TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
     }
-    TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
+    STD_TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
 
     if (bias_.has_value()) {
         auto bias = bias_.value();
-        TORCH_CHECK(bias.scalar_type() == weight_type);
-        TORCH_CHECK(bias.is_cuda());
-        TORCH_CHECK(bias.stride(-1) == 1);
+        STD_TORCH_CHECK(bias.scalar_type() == weight_type);
+        STD_TORCH_CHECK(bias.is_cuda());
+        STD_TORCH_CHECK(bias.stride(-1) == 1);
         CHECK_SHAPE(bias, dim);
     }
 
     if (seq_idx_.has_value()) {
-        TORCH_CHECK(is_channel_last, "seq_idx is only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "seq_idx is only supported for channel last layout");
         auto seq_idx = seq_idx_.value();
-        TORCH_CHECK(seq_idx.scalar_type() == torch::kInt32);
-        TORCH_CHECK(seq_idx.is_cuda());
-        TORCH_CHECK(seq_idx.is_contiguous());
+        STD_TORCH_CHECK(seq_idx.scalar_type() == ScalarType::Int);
+        STD_TORCH_CHECK(seq_idx.is_cuda());
+        STD_TORCH_CHECK(seq_idx.is_contiguous());
         CHECK_SHAPE(seq_idx, batch_size, seqlen);
     }
 
@@ -210,12 +237,12 @@ causal_conv1d_fwd(const at::Tensor &x,
     }
 
     if (initial_states_.has_value()) {
-        TORCH_CHECK(is_channel_last, "initial_states is only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "initial_states is only supported for channel last layout");
         auto initial_states = initial_states_.value();
-        TORCH_CHECK(initial_states.scalar_type() == input_type);
-        TORCH_CHECK(initial_states.is_cuda());
+        STD_TORCH_CHECK(initial_states.scalar_type() == input_type);
+        STD_TORCH_CHECK(initial_states.is_cuda());
         CHECK_SHAPE(initial_states, batch_size, dim, width - 1);
-        TORCH_CHECK(initial_states.stride(1) == 1);
+        STD_TORCH_CHECK(initial_states.stride(1) == 1);
         params.initial_states_ptr = initial_states.data_ptr();
         params.initial_states_batch_stride = initial_states.stride(0);
         params.initial_states_c_stride = initial_states.stride(1);
@@ -225,12 +252,12 @@ causal_conv1d_fwd(const at::Tensor &x,
     }
 
     if (final_states_out_.has_value()) {
-        TORCH_CHECK(is_channel_last, "final_states is only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "final_states is only supported for channel last layout");
         auto final_states = final_states_out_.value();
-        TORCH_CHECK(final_states.scalar_type() == input_type);
-        TORCH_CHECK(final_states.is_cuda());
+        STD_TORCH_CHECK(final_states.scalar_type() == input_type);
+        STD_TORCH_CHECK(final_states.is_cuda());
         CHECK_SHAPE(final_states, batch_size, dim, width - 1);
-        TORCH_CHECK(final_states.stride(1) == 1);
+        STD_TORCH_CHECK(final_states.stride(1) == 1);
         params.final_states_ptr = final_states.data_ptr();
         params.final_states_batch_stride = final_states.stride(0);
         params.final_states_c_stride = final_states.stride(1);
@@ -240,14 +267,10 @@ causal_conv1d_fwd(const at::Tensor &x,
     }
 
     // Otherwise the kernel will be launched from cuda:0 device
-#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
-    c10::DeviceGuard device_guard(x.device());
-#else
-    at::cuda::CUDAGuard device_guard{x.device()};
-#endif
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_fwd", [&] {
-        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_fwd", [&] {
+    torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+    auto stream = get_cuda_stream(x);
+    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(input_type, causal_conv1d_fwd, [&] {
+        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight_type, causal_conv1d_fwd, [&] {
             if (!is_channel_last) {
                 causal_conv1d_fwd_cuda<input_t, weight_t>(params, stream);
             } else {
@@ -258,27 +281,28 @@ causal_conv1d_fwd(const at::Tensor &x,
 }
 
 void
-causal_conv1d_bwd(const at::Tensor &x,
-                  const at::Tensor &weight,
-                  const c10::optional<at::Tensor> &bias_,
-                  at::Tensor &dout,
-                  const c10::optional<at::Tensor> &seq_idx_,
-                  const c10::optional<at::Tensor> &initial_states_,
-                  const c10::optional<at::Tensor> &dfinal_states_,
-                  at::Tensor &dx,
-                  at::Tensor &dweight,
-                  c10::optional<at::Tensor> &dbias_,
-                  c10::optional<at::Tensor> &dinitial_states_,
-                  bool silu_activation) {
+causal_conv1d_bwd(const Tensor &x,
+                  const Tensor &weight,
+                  const std::optional<Tensor> &bias_,
+                  Tensor dout,
+                  const std::optional<Tensor> &seq_idx_,
+                  const std::optional<Tensor> &initial_states_,
+                  const std::optional<Tensor> &dfinal_states_,
+                  Tensor dx,
+                  Tensor dweight,
+                  std::optional<Tensor> dbias_,
+                  std::optional<Tensor> dinitial_states_,
+                  bool silu_activation,
+                  bool deterministic) {
     auto input_type = x.scalar_type();
     auto weight_type = weight.scalar_type();
-    TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
-    TORCH_CHECK(weight_type == at::ScalarType::Float || weight_type == at::ScalarType::Half || weight_type == at::ScalarType::BFloat16);
+    STD_TORCH_CHECK(input_type == ScalarType::Float || input_type == ScalarType::Half || input_type == ScalarType::BFloat16);
+    STD_TORCH_CHECK(weight_type == ScalarType::Float || weight_type == ScalarType::Half || weight_type == ScalarType::BFloat16);
 
-    TORCH_CHECK(x.is_cuda());
-    TORCH_CHECK(weight.is_cuda());
-    TORCH_CHECK(dout.is_cuda());
-    TORCH_CHECK(bias_.has_value() == dbias_.has_value());
+    STD_TORCH_CHECK(x.is_cuda());
+    STD_TORCH_CHECK(weight.is_cuda());
+    STD_TORCH_CHECK(dout.is_cuda());
+    STD_TORCH_CHECK(bias_.has_value() == dbias_.has_value());
 
     const auto sizes = x.sizes();
     const int batch_size = sizes[0];
@@ -286,53 +310,49 @@ causal_conv1d_bwd(const at::Tensor &x,
     const int seqlen = sizes[2];
     const int width = weight.size(-1);
 
-    TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
+    STD_TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
 
     CHECK_SHAPE(x, batch_size, dim, seqlen);
     CHECK_SHAPE(weight, dim, width);
     CHECK_SHAPE(dout, batch_size, dim, seqlen);
 
-    TORCH_CHECK(x.stride(2) == 1 || x.stride(1) == 1);
+    STD_TORCH_CHECK(x.stride(2) == 1 || x.stride(1) == 1);
     const bool is_channel_last = x.stride(1) == 1 && x.stride(2) > 1;
-    if (!is_channel_last && dout.stride(2) != 1) { dout = dout.contiguous(); }
-    if (is_channel_last && dout.stride(1) != 1) { dout = dout.transpose(-1, -2).contiguous().transpose(-1, -2); }
+    if (!is_channel_last && dout.stride(2) != 1) { dout = torch::stable::contiguous(dout); }
+    if (is_channel_last && dout.stride(1) != 1) { dout = torch::stable::transpose(torch::stable::contiguous(torch::stable::transpose(dout, 1, 2)), 1, 2); }
 
     if (is_channel_last) {
-        TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
-        TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
-        TORCH_CHECK(dout.stride(2) % 8 == 0 && dout.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (dout.stride(0) and dout.stride(2)) to be multiples of 8");
+        STD_TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
+        STD_TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
+        STD_TORCH_CHECK(dout.stride(2) % 8 == 0 && dout.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (dout.stride(0) and dout.stride(2)) to be multiples of 8");
     }
 
     if (bias_.has_value()) {
         auto bias = bias_.value();
-        TORCH_CHECK(bias.scalar_type() == weight_type);
-        TORCH_CHECK(bias.is_cuda());
-        TORCH_CHECK(bias.stride(-1) == 1);
+        STD_TORCH_CHECK(bias.scalar_type() == weight_type);
+        STD_TORCH_CHECK(bias.is_cuda());
+        STD_TORCH_CHECK(bias.stride(-1) == 1);
         CHECK_SHAPE(bias, dim);
     }
 
     if (seq_idx_.has_value()) {
-        TORCH_CHECK(is_channel_last, "seq_idx only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "seq_idx only supported for channel last layout");
         auto seq_idx = seq_idx_.value();
-        TORCH_CHECK(seq_idx.scalar_type() == torch::kInt32);
-        TORCH_CHECK(seq_idx.is_cuda());
-        TORCH_CHECK(seq_idx.is_contiguous());
+        STD_TORCH_CHECK(seq_idx.scalar_type() == ScalarType::Int);
+        STD_TORCH_CHECK(seq_idx.is_cuda());
+        STD_TORCH_CHECK(seq_idx.is_contiguous());
         CHECK_SHAPE(seq_idx, batch_size, seqlen);
     }
 
-    TORCH_CHECK(dx.scalar_type() == input_type);
-    TORCH_CHECK(dx.is_cuda());
+    STD_TORCH_CHECK(dx.scalar_type() == input_type);
+    STD_TORCH_CHECK(dx.is_cuda());
     CHECK_SHAPE(dx, batch_size, dim, seqlen);
-    if (!is_channel_last) { TORCH_CHECK(dx.stride(2) == 1); }
-    if (is_channel_last) { TORCH_CHECK(dx.stride(1) == 1); }
+    if (!is_channel_last) { STD_TORCH_CHECK(dx.stride(2) == 1); }
+    if (is_channel_last) { STD_TORCH_CHECK(dx.stride(1) == 1); }
 
     // Otherwise the kernel will be launched from cuda:0 device
-#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
-    c10::Device device = x.device();
-    c10::DeviceGuard device_guard(device);
-#else
-    at::cuda::CUDAGuard device_guard{x.device()};
-#endif
+    torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+
     ConvParamsBwd params;
     set_conv_params_bwd(params, batch_size, dim, seqlen, width,
                         x, weight, bias_.has_value() ? bias_.value().data_ptr() : nullptr,
@@ -346,12 +366,12 @@ causal_conv1d_bwd(const at::Tensor &x,
     }
 
     if (initial_states_.has_value()) {
-        TORCH_CHECK(is_channel_last, "initial_states is only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "initial_states is only supported for channel last layout");
         auto initial_states = initial_states_.value();
-        TORCH_CHECK(initial_states.scalar_type() == input_type);
-        TORCH_CHECK(initial_states.is_cuda());
+        STD_TORCH_CHECK(initial_states.scalar_type() == input_type);
+        STD_TORCH_CHECK(initial_states.is_cuda());
         CHECK_SHAPE(initial_states, batch_size, dim, width - 1);
-        TORCH_CHECK(initial_states.stride(1) == 1);
+        STD_TORCH_CHECK(initial_states.stride(1) == 1);
         params.initial_states_ptr = initial_states.data_ptr();
         params.initial_states_batch_stride = initial_states.stride(0);
         params.initial_states_c_stride = initial_states.stride(1);
@@ -361,10 +381,10 @@ causal_conv1d_bwd(const at::Tensor &x,
     }
 
     if (dfinal_states_.has_value()) {
-        TORCH_CHECK(is_channel_last, "dfinal_states is only supported for channel last layout");
+        STD_TORCH_CHECK(is_channel_last, "dfinal_states is only supported for channel last layout");
         auto dfinal_states = dfinal_states_.value();
-        TORCH_CHECK(dfinal_states.scalar_type() == input_type);
-        TORCH_CHECK(dfinal_states.is_cuda());
+        STD_TORCH_CHECK(dfinal_states.scalar_type() == input_type);
+        STD_TORCH_CHECK(dfinal_states.is_cuda());
         CHECK_SHAPE(dfinal_states, batch_size, dim, width - 1);
         params.dfinal_states_ptr = dfinal_states.data_ptr();
         params.dfinal_states_batch_stride = dfinal_states.stride(0);
@@ -375,8 +395,8 @@ causal_conv1d_bwd(const at::Tensor &x,
     }
 
     if (dinitial_states_.has_value()) {
-        at::Tensor dinitial_states = dinitial_states_.value();
-        TORCH_CHECK(dinitial_states.stride(1) == 1);
+        Tensor dinitial_states = dinitial_states_.value();
+        STD_TORCH_CHECK(dinitial_states.stride(1) == 1);
         params.dinitial_states_ptr = dinitial_states.data_ptr();
         params.dinitial_states_batch_stride = dinitial_states.stride(0);
         params.dinitial_states_c_stride = dinitial_states.stride(1);
@@ -385,25 +405,24 @@ causal_conv1d_bwd(const at::Tensor &x,
         params.dinitial_states_ptr = nullptr;
     }
 
-    const bool deterministic = use_deterministic_mode();
     params.deterministic = deterministic;
 
-    at::Tensor dweight_workspace;
-    at::Tensor dbias_workspace;
+    std::optional<Tensor> dweight_workspace;
+    std::optional<Tensor> dbias_workspace;
 
     if (deterministic) {
         if (!is_channel_last) {
-            dweight_workspace = at::zeros({batch_size, dim, width},
-                at::TensorOptions().dtype(at::kFloat).device(x.device()));
-            params.dweight_workspace_ptr = dweight_workspace.data_ptr();
-            params.dweight_workspace_batch_stride = dweight_workspace.stride(0);
-            params.dweight_workspace_dim_stride = dweight_workspace.stride(1);
+            dweight_workspace.emplace(
+                torch::stable::new_zeros(x, {batch_size, dim, width}, ScalarType::Float));
+            params.dweight_workspace_ptr = dweight_workspace->data_ptr();
+            params.dweight_workspace_batch_stride = dweight_workspace->stride(0);
+            params.dweight_workspace_dim_stride = dweight_workspace->stride(1);
 
             if (dbias_.has_value()) {
-                dbias_workspace = at::zeros({batch_size, dim},
-                    at::TensorOptions().dtype(at::kFloat).device(x.device()));
-                params.dbias_workspace_ptr = dbias_workspace.data_ptr();
-                params.dbias_workspace_batch_stride = dbias_workspace.stride(0);
+                dbias_workspace.emplace(
+                    torch::stable::new_zeros(x, {batch_size, dim}, ScalarType::Float));
+                params.dbias_workspace_ptr = dbias_workspace->data_ptr();
+                params.dbias_workspace_batch_stride = dbias_workspace->stride(0);
             } else {
                 params.dbias_workspace_ptr = nullptr;
                 params.dbias_workspace_batch_stride = 0;
@@ -412,17 +431,17 @@ causal_conv1d_bwd(const at::Tensor &x,
             const int kChunkSizeL = seqlen <= 128 ? 64 : 128;
             const int n_chunks_L = (seqlen + kChunkSizeL - 1) / kChunkSizeL;
 
-            dweight_workspace = at::zeros({batch_size, n_chunks_L, dim, width},
-                at::TensorOptions().dtype(at::kFloat).device(x.device()));
-            params.dweight_workspace_ptr = dweight_workspace.data_ptr();
-            params.dweight_workspace_batch_stride = dweight_workspace.stride(0);
-            params.dweight_workspace_dim_stride = dweight_workspace.stride(2);
+            dweight_workspace.emplace(
+                torch::stable::new_zeros(x, {batch_size, n_chunks_L, dim, width}, ScalarType::Float));
+            params.dweight_workspace_ptr = dweight_workspace->data_ptr();
+            params.dweight_workspace_batch_stride = dweight_workspace->stride(0);
+            params.dweight_workspace_dim_stride = dweight_workspace->stride(2);
 
             if (dbias_.has_value()) {
-                dbias_workspace = at::zeros({batch_size, n_chunks_L, dim},
-                    at::TensorOptions().dtype(at::kFloat).device(x.device()));
-                params.dbias_workspace_ptr = dbias_workspace.data_ptr();
-                params.dbias_workspace_batch_stride = dbias_workspace.stride(0);
+                dbias_workspace.emplace(
+                    torch::stable::new_zeros(x, {batch_size, n_chunks_L, dim}, ScalarType::Float));
+                params.dbias_workspace_ptr = dbias_workspace->data_ptr();
+                params.dbias_workspace_batch_stride = dbias_workspace->stride(0);
             } else {
                 params.dbias_workspace_ptr = nullptr;
                 params.dbias_workspace_batch_stride = 0;
@@ -436,9 +455,9 @@ causal_conv1d_bwd(const at::Tensor &x,
         params.dbias_workspace_batch_stride = 0;
     }
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_bwd", [&] {
-        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_bwd", [&] {
+    auto stream = get_cuda_stream(x);
+    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(input_type, causal_conv1d_bwd, [&] {
+        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight_type, causal_conv1d_bwd, [&] {
             if (!is_channel_last) {
                 causal_conv1d_bwd_cuda<input_t, weight_t>(params, stream);
             } else {
@@ -449,38 +468,38 @@ causal_conv1d_bwd(const at::Tensor &x,
 
     if (deterministic) {
         if (!is_channel_last) {
-            dweight.add_(dweight_workspace.sum(0));
+            add_workspace_sum_in_place(dweight, *dweight_workspace, {0});
             if (dbias_.has_value()) {
-                dbias_.value().add_(dbias_workspace.sum(0));
+                add_workspace_sum_in_place(*dbias_, *dbias_workspace, {0});
             }
         } else {
-            dweight.add_(dweight_workspace.sum(at::IntArrayRef({0, 1})));
+            add_workspace_sum_in_place(dweight, *dweight_workspace, {0, 1});
             if (dbias_.has_value()) {
-                dbias_.value().add_(dbias_workspace.sum(at::IntArrayRef({0, 1})));
+                add_workspace_sum_in_place(*dbias_, *dbias_workspace, {0, 1});
             }
         }
     }
 }
 
 void
-causal_conv1d_update(const at::Tensor &x,
-                     const at::Tensor &conv_state,
-                     const at::Tensor &weight,
-                     const c10::optional<at::Tensor> &bias_,
-                     at::Tensor &out,
+causal_conv1d_update(const Tensor &x,
+                     const Tensor &conv_state,
+                     const Tensor &weight,
+                     const std::optional<Tensor> &bias_,
+                     Tensor out,
                      bool silu_activation,
-                     const c10::optional<at::Tensor> &cache_seqlens_,
-                     const c10::optional<at::Tensor> &conv_state_indices_
+                     const std::optional<Tensor> &cache_seqlens_,
+                     const std::optional<Tensor> &conv_state_indices_
                      ) {
     auto input_type = x.scalar_type();
     auto weight_type = weight.scalar_type();
-    TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
-    TORCH_CHECK(weight_type == at::ScalarType::Float || weight_type == at::ScalarType::Half || weight_type == at::ScalarType::BFloat16);
-    TORCH_CHECK(conv_state.scalar_type() == input_type);
+    STD_TORCH_CHECK(input_type == ScalarType::Float || input_type == ScalarType::Half || input_type == ScalarType::BFloat16);
+    STD_TORCH_CHECK(weight_type == ScalarType::Float || weight_type == ScalarType::Half || weight_type == ScalarType::BFloat16);
+    STD_TORCH_CHECK(conv_state.scalar_type() == input_type);
 
-    TORCH_CHECK(x.is_cuda());
-    TORCH_CHECK(conv_state.is_cuda());
-    TORCH_CHECK(weight.is_cuda());
+    STD_TORCH_CHECK(x.is_cuda());
+    STD_TORCH_CHECK(conv_state.is_cuda());
+    STD_TORCH_CHECK(weight.is_cuda());
 
     const auto sizes = x.sizes();
     const int batch_size = sizes[0];
@@ -488,18 +507,18 @@ causal_conv1d_update(const at::Tensor &x,
     const int seqlen = sizes[2];
     const int width = weight.size(-1);
     const int conv_state_len = conv_state.size(2);
-    TORCH_CHECK(conv_state_len >= width - 1);
+    STD_TORCH_CHECK(conv_state_len >= width - 1);
 
     CHECK_SHAPE(x, batch_size, dim, seqlen);
     CHECK_SHAPE(weight, dim, width);
 
-    TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
+    STD_TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
 
     if (bias_.has_value()) {
         auto bias = bias_.value();
-        TORCH_CHECK(bias.scalar_type() == weight_type);
-        TORCH_CHECK(bias.is_cuda());
-        TORCH_CHECK(bias.stride(-1) == 1);
+        STD_TORCH_CHECK(bias.scalar_type() == weight_type);
+        STD_TORCH_CHECK(bias.is_cuda());
+        STD_TORCH_CHECK(bias.stride(-1) == 1);
         CHECK_SHAPE(bias, dim);
     }
 
@@ -516,15 +535,15 @@ causal_conv1d_update(const at::Tensor &x,
 
     if (conv_state_indices_.has_value()) {
         auto conv_state_indices = conv_state_indices_.value();
-        TORCH_CHECK(conv_state_indices.scalar_type() == torch::kInt32)
-        TORCH_CHECK(conv_state_indices.is_cuda());
-        TORCH_CHECK(conv_state_indices.stride(0) == 1)
+        STD_TORCH_CHECK(conv_state_indices.scalar_type() == ScalarType::Int);
+        STD_TORCH_CHECK(conv_state_indices.is_cuda());
+        STD_TORCH_CHECK(conv_state_indices.stride(0) == 1);
         CHECK_SHAPE(conv_state_indices, batch_size);
 
-        int conv_state_entries = conv_state.size(0);
+        const int conv_state_entries = conv_state.size(0);
         CHECK_SHAPE(conv_state, conv_state_entries, dim, conv_state_len);
 
-        params.conv_state_indices_ptr = conv_state_indices.data_ptr<int32_t>();
+        params.conv_state_indices_ptr = static_cast<int32_t*>(conv_state_indices.data_ptr());
     } else {
         CHECK_SHAPE(conv_state, batch_size, dim, conv_state_len);
         params.conv_state_indices_ptr = nullptr;
@@ -532,32 +551,44 @@ causal_conv1d_update(const at::Tensor &x,
 
     if (cache_seqlens_.has_value()) {
         auto cache_seqlens = cache_seqlens_.value();
-        TORCH_CHECK(cache_seqlens.scalar_type() == torch::kInt32);
-        TORCH_CHECK(cache_seqlens.is_cuda());
-        TORCH_CHECK(cache_seqlens.stride(-1) == 1);
+        STD_TORCH_CHECK(cache_seqlens.scalar_type() == ScalarType::Int);
+        STD_TORCH_CHECK(cache_seqlens.is_cuda());
+        STD_TORCH_CHECK(cache_seqlens.stride(-1) == 1);
         CHECK_SHAPE(cache_seqlens, batch_size);
-        params.cache_seqlens = cache_seqlens.data_ptr<int32_t>();
+        params.cache_seqlens = static_cast<int32_t*>(cache_seqlens.data_ptr());
     } else {
         params.cache_seqlens = nullptr;
     }
 
     // Otherwise the kernel will be launched from cuda:0 device
-#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 6)
-    c10::Device device = x.device();
-    c10::DeviceGuard device_guard(device);
-#else
-    at::cuda::CUDAGuard device_guard{x.device()};
-#endif
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_update", [&] {
-        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_update", [&] {
+    torch::stable::accelerator::DeviceGuard device_guard(x.get_device_index());
+    auto stream = get_cuda_stream(x);
+    DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(input_type, causal_conv1d_update, [&] {
+        DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight_type, causal_conv1d_update, [&] {
             causal_conv1d_update_cuda<input_t, weight_t>(params, stream);
         });
     });
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("causal_conv1d_fwd", &causal_conv1d_fwd, "Causal conv1d forward");
-    m.def("causal_conv1d_bwd", &causal_conv1d_bwd, "Causal conv1d backward");
-    m.def("causal_conv1d_update", &causal_conv1d_update, "Causal conv1d update");
+PyMODINIT_FUNC PyInit_causal_conv1d_cuda(void) {
+    static struct PyModuleDef module_def = {
+        PyModuleDef_HEAD_INIT,
+        "causal_conv1d_cuda",
+        nullptr,
+        -1,
+        nullptr,
+    };
+    return PyModule_Create(&module_def);
+}
+
+STABLE_TORCH_LIBRARY(causal_conv1d_cuda, m) {
+    m.def("causal_conv1d_fwd(Tensor x, Tensor weight, Tensor? bias, Tensor? seq_idx, Tensor? initial_states, Tensor(a!) out, Tensor(b!)? final_states_out, bool silu_activation) -> ()");
+    m.def("causal_conv1d_bwd(Tensor x, Tensor weight, Tensor? bias, Tensor dout, Tensor? seq_idx, Tensor? initial_states, Tensor? dfinal_states, Tensor(a!) dx, Tensor(b!) dweight, Tensor(c!)? dbias, Tensor(d!)? dinitial_states, bool silu_activation, bool deterministic) -> ()");
+    m.def("causal_conv1d_update(Tensor x, Tensor(a!) conv_state, Tensor weight, Tensor? bias, Tensor(b!) out, bool silu_activation, Tensor? cache_seqlens, Tensor? conv_state_indices) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(causal_conv1d_cuda, CUDA, m) {
+    m.impl("causal_conv1d_fwd", TORCH_BOX(&causal_conv1d_fwd));
+    m.impl("causal_conv1d_bwd", TORCH_BOX(&causal_conv1d_bwd));
+    m.impl("causal_conv1d_update", TORCH_BOX(&causal_conv1d_update));
 }

--- a/csrc/causal_conv1d_bwd.cu
+++ b/csrc/causal_conv1d_bwd.cu
@@ -2,9 +2,8 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
-#include <c10/util/BFloat16.h>
-#include <c10/util/Half.h>
-#include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
 
 #ifndef USE_ROCM
     #include <cub/block/block_load.cuh>
@@ -17,6 +16,7 @@
     #define ROCM_ONLY(x) x
 #endif
 
+#include "causal_conv1d_cuda_compat.h"  // For CAUSAL_CONV1D_CUDA_CHECK and CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK
 #include "causal_conv1d.h"
 #include "causal_conv1d_common.h"
 #include "static_switch.h"
@@ -270,12 +270,12 @@ void causal_conv1d_bwd_launch(ConvParamsBwd &params, cudaStream_t stream) {
                 auto kernel = &causal_conv1d_bwd_kernel<Ktraits, kDeterministic>;
                 if (kSmemSize >= 48 * 1024) {
                     // There is a slight signature discrepancy in HIP and CUDA "FuncSetAttribute" function.
-                    C10_CUDA_CHECK(cudaFuncSetAttribute(
+                    CAUSAL_CONV1D_CUDA_CHECK(cudaFuncSetAttribute(
                         ROCM_ONLY((void *)) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
                     ROCM_ONLY(std::cerr << "Warning (causal_conv1d bwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl);
                 }
                 kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
+                CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK();
             });
         });
     });
@@ -612,7 +612,7 @@ void causal_conv1d_channellast_bwd_launch(ConvParamsBwd &params, cudaStream_t st
                         //     }
                         // kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
                         kernel<<<grid, Ktraits::kNThreads, 0, stream>>>(params);
-                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                        CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK();
                     });
                 });
             });
@@ -632,21 +632,21 @@ void causal_conv1d_channellast_bwd_cuda(ConvParamsBwd &params, cudaStream_t stre
 }
 
 template void causal_conv1d_bwd_cuda<float, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::Half, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::BFloat16, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<float, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::Half, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::BFloat16, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<float, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::Half, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_bwd_cuda<at::BFloat16, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::Half, float>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::BFloat16, float>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<float, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::Half, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::BFloat16, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<float, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::Half, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_bwd_cuda<torch::headeronly::BFloat16, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
 
 template void causal_conv1d_channellast_bwd_cuda<float, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::Half, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::BFloat16, float>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<float, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::Half, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::BFloat16, at::Half>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<float, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::Half, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
-template void causal_conv1d_channellast_bwd_cuda<at::BFloat16, at::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::Half, float>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::BFloat16, float>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<float, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::Half, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::BFloat16, torch::headeronly::Half>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<float, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::Half, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);
+template void causal_conv1d_channellast_bwd_cuda<torch::headeronly::BFloat16, torch::headeronly::BFloat16>(ConvParamsBwd &params, cudaStream_t stream);

--- a/csrc/causal_conv1d_cuda_compat.h
+++ b/csrc/causal_conv1d_cuda_compat.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+inline void causal_conv1d_cuda_check_impl(
+    cudaError_t error,
+    const char* expr,
+    const char* file,
+    int line) {
+    if (error == cudaSuccess) {
+        return;
+    }
+    throw std::runtime_error(
+        std::string("CUDA runtime error at ") + file + ":" + std::to_string(line)
+        + " for " + expr + ": " + cudaGetErrorString(error));
+}
+
+#define CAUSAL_CONV1D_CUDA_CHECK(expr) \
+    causal_conv1d_cuda_check_impl((expr), #expr, __FILE__, __LINE__)
+
+#define CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK() \
+    CAUSAL_CONV1D_CUDA_CHECK(cudaGetLastError())

--- a/csrc/causal_conv1d_fwd.cu
+++ b/csrc/causal_conv1d_fwd.cu
@@ -2,9 +2,8 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
-#include <c10/util/BFloat16.h>
-#include <c10/util/Half.h>
-#include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
 
 #ifndef USE_ROCM
     #include <cub/block/block_load.cuh>
@@ -16,6 +15,7 @@
     #define ROCM_ONLY(x) x
 #endif
 
+#include "causal_conv1d_cuda_compat.h"  // For CAUSAL_CONV1D_CUDA_CHECK and CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK
 #include "causal_conv1d.h"
 #include "causal_conv1d_common.h"
 #include "static_switch.h"
@@ -148,13 +148,13 @@ void causal_conv1d_fwd_launch(ConvParamsBase &params, cudaStream_t stream) {
 
         if (kSmemSize >= 48 * 1024) {
             // There is a slight signature discrepancy in HIP and CUDA "FuncSetAttribute" function.
-            C10_CUDA_CHECK(cudaFuncSetAttribute(
+            CAUSAL_CONV1D_CUDA_CHECK(cudaFuncSetAttribute(
                 ROCM_ONLY((void *)) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
             ROCM_ONLY(std::cerr << "Warning (causal_conv1d fwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl);
         }
         kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
 
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK();
     });
 }
 
@@ -365,7 +365,7 @@ void causal_conv1d_channellast_fwd_launch(ConvParamsBase &params, cudaStream_t s
         //     }
         // kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
         kernel<<<grid, Ktraits::kNThreads, 0, stream>>>(params);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK();
     });
 }
 
@@ -381,21 +381,21 @@ void causal_conv1d_channellast_fwd_cuda(ConvParamsBase &params, cudaStream_t str
 }
 
 template void causal_conv1d_fwd_cuda<float, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::Half, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<float, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::Half, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::BFloat16, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<float, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::Half, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_fwd_cuda<at::BFloat16, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::Half, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<float, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::Half, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::BFloat16, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<float, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::Half, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_fwd_cuda<torch::headeronly::BFloat16, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
 
 template void causal_conv1d_channellast_fwd_cuda<float, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::Half, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<float, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::Half, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::BFloat16, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<float, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::Half, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_channellast_fwd_cuda<at::BFloat16, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::Half, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<float, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::Half, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::BFloat16, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<float, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::Half, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_channellast_fwd_cuda<torch::headeronly::BFloat16, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);

--- a/csrc/causal_conv1d_update.cu
+++ b/csrc/causal_conv1d_update.cu
@@ -2,10 +2,10 @@
  * Copyright (c) 2023, Tri Dao.
  ******************************************************************************/
 
-#include <c10/util/BFloat16.h>
-#include <c10/util/Half.h>
-#include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#include <torch/headeronly/util/BFloat16.h>
+#include <torch/headeronly/util/Half.h>
 
+#include "causal_conv1d_cuda_compat.h"  // For CAUSAL_CONV1D_CUDA_CHECK and CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK
 #include "causal_conv1d.h"
 #include "causal_conv1d_common.h"
 #include "static_switch.h"
@@ -121,7 +121,7 @@ void causal_conv1d_update_launch(ConvParamsBase &params, cudaStream_t stream) {
         ? &causal_conv1d_update_kernel<Ktraits, false>
         : &causal_conv1d_update_kernel<Ktraits, true>;
     kernel<<<grid, Ktraits::kNThreads, 0, stream>>>(params);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    CAUSAL_CONV1D_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template<typename input_t, typename weight_t>
@@ -136,11 +136,11 @@ void causal_conv1d_update_cuda(ConvParamsBase &params, cudaStream_t stream) {
 }
 
 template void causal_conv1d_update_cuda<float, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::Half, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<float, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::Half, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::BFloat16, at::Half>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<float, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::Half, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
-template void causal_conv1d_update_cuda<at::BFloat16, at::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::Half, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::BFloat16, float>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<float, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::Half, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::BFloat16, torch::headeronly::Half>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<float, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::Half, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);
+template void causal_conv1d_update_cuda<torch::headeronly::BFloat16, torch::headeronly::BFloat16>(ConvParamsBase &params, cudaStream_t stream);

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ from torch.utils.cpp_extension import (
     CUDAExtension,
     CUDA_HOME,
     HIP_HOME,
+    min_supported_cpython,
 )
 
 
@@ -35,6 +36,9 @@ with open("README.md", "r", encoding="utf-8") as fh:
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
 PACKAGE_NAME = "causal_conv1d"
+TORCH_TARGET_VERSION = "0x020a000000000000"
+PY_LIMITED_API_TAG = f"cp{(int(min_supported_cpython, 16) >> 24) & 0xFF}{(int(min_supported_cpython, 16) >> 16) & 0xFF}"
+PYTHON_REQUIRES_TAG = f">={(int(min_supported_cpython, 16) >> 24) & 0xFF}.{(int(min_supported_cpython, 16) >> 16) & 0xFF}"
 
 BASE_WHEEL_URL = "https://github.com/Dao-AILab/causal-conv1d/releases/download/{tag_name}/{wheel_name}"
 
@@ -203,10 +207,11 @@ if not SKIP_CUDA_BUILD:
 
     if HIP_BUILD:
         extra_compile_args = {
-            "cxx": ["-O3", "-std=c++17"],
+            "cxx": ["-O3", "-std=c++17", f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"],
             "nvcc": [
                 "-O3",
                 "-std=c++17",
+                f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}",
                 f"--offload-arch={os.getenv('HIP_ARCHITECTURES', 'native')}",
                 "-U__CUDA_NO_HALF_OPERATORS__",
                 "-U__CUDA_NO_HALF_CONVERSIONS__",
@@ -216,10 +221,12 @@ if not SKIP_CUDA_BUILD:
         }
     else:
         extra_compile_args = {
-            "cxx": ["-O3"],
+            "cxx": ["-O3", "-std=c++17", f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"],
             "nvcc": append_nvcc_threads(
                 [
                     "-O3",
+                    "-std=c++17",
+                    f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",
                     "-U__CUDA_NO_BFLOAT16_OPERATORS__",
@@ -247,6 +254,7 @@ if not SKIP_CUDA_BUILD:
             ],
             extra_compile_args=extra_compile_args,
             include_dirs=[Path(this_dir) / "csrc"],
+            py_limited_api=True,
         )
     )
 
@@ -376,10 +384,11 @@ setup(
     else {
         "bdist_wheel": CachedWheelsCommand,
     },
-    python_requires=">=3.9",
+    python_requires=PYTHON_REQUIRES_TAG,
     install_requires=[
         "torch",
         "packaging",
         "ninja",
     ],
+    options={"bdist_wheel": {"py_limited_api": PY_LIMITED_API_TAG}},
 )

--- a/setup.py
+++ b/setup.py
@@ -221,11 +221,12 @@ if not SKIP_CUDA_BUILD:
         }
     else:
         extra_compile_args = {
-            "cxx": ["-O3", "-std=c++17", f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"],
+            "cxx": ["-O3", "-std=c++17", "-DUSE_CUDA", f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"],
             "nvcc": append_nvcc_threads(
                 [
                     "-O3",
                     "-std=c++17",
+                    "-DUSE_CUDA",
                     f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",
@@ -236,7 +237,10 @@ if not SKIP_CUDA_BUILD:
                     "--expt-relaxed-constexpr",
                     "--expt-extended-lambda",
                     "--use_fast_math",
-                    "--ptxas-options=-v",
+                    "-diag-suppress=174",
+                    "-diag-suppress=177",
+                    "-diag-suppress=221",
+                    # "--ptxas-options=-v",
                     "-lineinfo",
                 ]
                 + cc_flag

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -9,6 +9,7 @@ import pytest
 
 from einops import rearrange
 
+import causal_conv1d.cpp_functions as causal_conv1d_cpp_functions
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_ref
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_update, causal_conv1d_update_ref
 from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states, causal_conv1d_varlen_states_ref
@@ -18,33 +19,32 @@ def _max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
     return (a.float() - b.float()).abs().max().item()
 
 
-def _conv1d_bwd_once(*, seed: int, channel_last: bool):
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    device = "cuda"
-    itype = torch.bfloat16
-    dim = 1024
-    seqlen = 2048
-    width = 4
+def _conv1d_bwd_once(*, seed: int, channel_last: bool, deterministic: bool):
+    old = causal_conv1d_cpp_functions.DETERMINISTIC
+    causal_conv1d_cpp_functions.DETERMINISTIC = deterministic
+    try:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        device = "cuda"
+        itype = torch.bfloat16
+        dim = 1024
+        seqlen = 2048
+        width = 4
 
-    batch = 4
-    if not channel_last:
-        x = torch.randn(batch, dim, seqlen, device=device, dtype=itype).requires_grad_()
-    else:
-        x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(1, 2).requires_grad_()
-    weight = torch.randn(dim, width, device=device, dtype=torch.float32, requires_grad=True)
-    bias = torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True)
-    g = torch.randn_like(x)
-    out = causal_conv1d_fn(x, weight, bias, activation="silu")
-    out.backward(g)
-    torch.cuda.synchronize()
-    return x.grad.detach().clone(), weight.grad.detach().clone(), bias.grad.detach().clone()
-
-
-def _set_torch_deterministic(enabled: bool) -> bool:
-    old = torch.are_deterministic_algorithms_enabled()
-    torch.use_deterministic_algorithms(enabled)
-    return old
+        batch = 4
+        if not channel_last:
+            x = torch.randn(batch, dim, seqlen, device=device, dtype=itype).requires_grad_()
+        else:
+            x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(1, 2).requires_grad_()
+        weight = torch.randn(dim, width, device=device, dtype=torch.float32, requires_grad=True)
+        bias = torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True)
+        g = torch.randn_like(x)
+        out = causal_conv1d_fn(x, weight, bias, activation="silu")
+        out.backward(g)
+        torch.cuda.synchronize()
+        return x.grad.detach().clone(), weight.grad.detach().clone(), bias.grad.detach().clone()
+    finally:
+        causal_conv1d_cpp_functions.DETERMINISTIC = old
 
 
 @pytest.mark.parametrize("return_final_states", [False, True])
@@ -559,60 +559,44 @@ def test_causal_conv1d_varlen_padding(dim, seqlen, width, has_bias, silu_activat
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("channel_last", [False, True])
-def test_causal_conv1d_bwd_deterministic_reproducible(channel_last: bool, monkeypatch):
-    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
-    old = _set_torch_deterministic(True)
-    try:
-        runs = 5
-        outs = [_conv1d_bwd_once(seed=123, channel_last=channel_last) for _ in range(runs)]
-        dx0, dw0, db0 = outs[0]
-        for i in range(1, runs):
-            dx, dw, db = outs[i]
-            assert _max_abs_diff(dx0, dx) == 0.0
-            assert _max_abs_diff(dw0, dw) == 0.0
-            assert _max_abs_diff(db0, db) == 0.0
-    finally:
-        torch.use_deterministic_algorithms(old)
+def test_causal_conv1d_bwd_deterministic_reproducible(channel_last: bool):
+    runs = 5
+    outs = [_conv1d_bwd_once(seed=123, channel_last=channel_last, deterministic=True) for _ in range(runs)]
+    dx0, dw0, db0 = outs[0]
+    for i in range(1, runs):
+        dx, dw, db = outs[i]
+        assert _max_abs_diff(dx0, dx) == 0.0
+        assert _max_abs_diff(dw0, dw) == 0.0
+        assert _max_abs_diff(db0, db) == 0.0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("channel_last", [False, True])
-def test_causal_conv1d_bwd_deterministic_close_to_default(channel_last: bool, monkeypatch):
+def test_causal_conv1d_bwd_deterministic_close_to_default(channel_last: bool):
     default_runs = 3
-    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
-    old = _set_torch_deterministic(True)
-    try:
-        dx_det, dw_det, db_det = _conv1d_bwd_once(seed=123, channel_last=channel_last)
-        torch.use_deterministic_algorithms(False)
-        for _ in range(default_runs):
-            dx_def, dw_def, db_def = _conv1d_bwd_once(seed=123, channel_last=channel_last)
-            assert torch.allclose(dx_det, dx_def, rtol=1e-2, atol=5e-2)
-            assert torch.allclose(dw_det, dw_def, rtol=1e-3, atol=1e-3)
-            assert torch.allclose(db_det, db_def, rtol=1e-3, atol=1e-3)
-    finally:
-        torch.use_deterministic_algorithms(old)
+    dx_det, dw_det, db_det = _conv1d_bwd_once(seed=123, channel_last=channel_last, deterministic=True)
+    for _ in range(default_runs):
+        dx_def, dw_def, db_def = _conv1d_bwd_once(seed=123, channel_last=channel_last, deterministic=False)
+        assert torch.allclose(dx_det, dx_def, rtol=1e-2, atol=5e-2)
+        assert torch.allclose(dw_det, dw_def, rtol=1e-3, atol=1e-3)
+        assert torch.allclose(db_det, db_def, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize("channel_last", [False, True])
-def test_causal_conv1d_bwd_default_mode_is_not_reproducible(channel_last: bool, monkeypatch):
-    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
-    old = _set_torch_deterministic(False)
-    try:
-        runs = 20
-        dw0 = None
-        db0 = None
-        dx0 = None
-        observed = False
-        for _ in range(runs):
-            dx, dw, db = _conv1d_bwd_once(seed=123, channel_last=channel_last)
-            if dw0 is None:
-                dx0, dw0, db0 = dx, dw, db
-                continue
-            if _max_abs_diff(dx0, dx) != 0.0 or _max_abs_diff(dw0, dw) != 0.0 or _max_abs_diff(db0, db) != 0.0:
-                observed = True
-                break
-        if not observed:
-            pytest.xfail("Did not observe nondeterminism in default mode (may be GPU/runtime dependent).")
-    finally:
-        torch.use_deterministic_algorithms(old)
+def test_causal_conv1d_bwd_default_mode_is_not_reproducible(channel_last: bool):
+    runs = 20
+    dw0 = None
+    db0 = None
+    dx0 = None
+    observed = False
+    for _ in range(runs):
+        dx, dw, db = _conv1d_bwd_once(seed=123, channel_last=channel_last, deterministic=False)
+        if dw0 is None:
+            dx0, dw0, db0 = dx, dw, db
+            continue
+        if _max_abs_diff(dx0, dx) != 0.0 or _max_abs_diff(dw0, dw) != 0.0 or _max_abs_diff(db0, db) != 0.0:
+            observed = True
+            break
+    if not observed:
+        pytest.xfail("Did not observe nondeterminism in default mode (may be GPU/runtime dependent).")


### PR DESCRIPTION
I've ported this repo to [Python stable ABI](https://docs.python.org/3/c-api/stable.html) (ABI3) and [libtorch stable ABI](https://docs.pytorch.org/docs/stable/notes/libtorch_stable_abi.html). See https://docs.pytorch.org/tutorials/advanced/cpp_custom_ops.html for a modern guide of torch custom ops.

This means we no longer need to build a different wheel for every Python and PyTorch version. We only need to build different wheels for Windows/Linux and CUDA 12/CUDA 13/ROCm 7. It will help the adoption of this package, notably because Unsloth is recommending this package in Qwen3.5 training. The same porting is already done in packages like flash-attn-3.

I've built the wheel and run the unit tests on a machine with Windows, RTX 3080 (sm86), CUDA 13, torch 2.11, and another machine with Linux, Strix Halo (gfx1151), ROCm 7, torch 2.12 nightly.

A concern is that libtorch stable ABI only supports Python >= 3.10 and torch >= 2.10 . It's possible to make it support torch 2.9 with some extra effort. As you've dropped support for Pascal and Volta, maybe we can also drop support for torch < 2.10 . Or we can keep the old code without stable ABI in a legacy branch.

A notable change is that I moved the detection of deterministic mode from C++ to Python, because it's not in the stable C++ API. Also, `os.getenv` cannot be traced in `torch.compile`, so I detect it when the package is imported rather than when the function is called. I've updated the corresponding tests.