### PR TITLE
setup: skip sm_103 cubin on CUDA 13.x (miscompile produces wrong fwd/update output on B300)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,8 +188,13 @@ if not SKIP_CUDA_BUILD:
             cc_flag.append("-gencode")
             cc_flag.append("arch=compute_120,code=sm_120")
         if bare_metal_version >= Version("13.0"):
-            cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_103,code=sm_103")
+            # Skip explicit `compute_103,sm_103` codegen even though nvcc 13.x
+            # supports it: nvcc 13.2 produces a numerically-broken cubin for
+            # `causal_conv1d_fwd` / `causal_conv1d_update` at this arch
+            # (max_abs_err ~0.4-0.6 on BF16, `update`'s in-place state write
+            # is dropped). The sm_100 cubin is forward-compatible to sm_103
+            # within the Blackwell family and gives bit-exact correct output
+            # on B300. See https://github.com/Dao-AILab/causal-conv1d/issues/105
             cc_flag.append("-gencode")
             cc_flag.append("arch=compute_110,code=sm_110")
             cc_flag.append("-gencode")


### PR DESCRIPTION
## What

Skip the explicit `compute_103,sm_103` gencode in `setup.py` when CUDA 13+ is detected. Source builds picked up the broken sm_103 cubin (nvcc 13.x miscompile of `fwd`/`update`) on B300 and silently returned wrong output; the published wheels were built with CUDA <13 and shipped only the sm_100 cubin, which is forward-compatible to sm_103 within the Blackwell family and is correct.

Fixes #105.

## Repro

`pip install causal-conv1d==1.6.1` (works on B300, max_abs_diff=0) vs `pip install causal-conv1d --no-binary causal-conv1d` with CUDA 13.2 (broken on B300, max_abs_diff ≈ 0.6). Full per-arch matrix in #105.

## Test plan

On B300 SXM6 AC, CUDA 13.2 V13.2.51, driver 580.x, BF16:

```
fwd_bf16_width4_no_init                                         PASS  max_abs_diff = 0
fwd_bf16_silu_no_init                                           PASS  max_abs_diff = 0
update_bf16_width4                                              PASS  state bit-exact
fwd_bf16_initial_states_silently_ignored_in_channel_first       PASS  drift_vs_no_init = 0
```

vs upstream `main` on the same hardware: all 4 fail with `max_abs_err = 0.4–0.6`.

## Risk

Low — the change is gencode-only. sm_100 is documented as forward-compatible to sm_103 within Blackwell, and the published wheels for 1.6.1 already rely on this for B300 today. Restoring `sm_103` after the nvcc bug is fixed is a one-line revert.

## Why not fix the kernel instead

The kernel source compiles cleanly for `sm_100` and `sm_103` from the same TU; the sm_100 cubin is correct, the sm_103 cubin is not. That points squarely at nvcc's SM103 codegen path (or the CUB version shipped with CUDA 13.2 picking a broken WARP_TRANSPOSE layout for SM103). Working around the codegen bug here is a one-line, reversible change; root-causing the toolchain bug shouldn't block correctness on shipping hardware.
