### PR TITLE
feat(ci): add weekly scheduled wheel build matrix

### DIFF
--- a/.github/scripts/check_for_releases.sh
+++ b/.github/scripts/check_for_releases.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+UPSTREAM_REPO="${UPSTREAM_REPO:?UPSTREAM_REPO must be set, e.g. Dao-AILab/causal-conv1d}"
+LIMIT="${LIMIT:-3}"
+OUTPUT_FILE="${OUTPUT_FILE:-releases.json}"
+
+echo "Fetching last ${LIMIT} stable releases of ${UPSTREAM_REPO}..."
+echo "---------------------------------------------------------------------"
+
+gh release list \
+  --repo "$UPSTREAM_REPO" \
+  --limit "$LIMIT" \
+  --exclude-drafts \
+  --exclude-pre-releases \
+  --json tagName \
+  --jq '[.[].tagName]' \
+  > "$OUTPUT_FILE"
+
+echo "Resolved release tags:"
+cat "$OUTPUT_FILE"
+echo
+echo "---"
+echo "Check complete."

--- a/.github/workflows/build_in_container.yml
+++ b/.github/workflows/build_in_container.yml
@@ -12,6 +12,7 @@ on:
         description: "Container image"
         required: true
         type: string
+        default: "nvcr.io/nvidia/pytorch:25.06-py3"
       upload-to-release:
         description: "Upload wheel to this release"
         required: false
@@ -45,29 +46,11 @@ jobs:
           fi
         shell: bash
 
-  check_for_ngc_images:
-    runs-on: ubuntu-latest
-    outputs:
-      images: ${{ steps.check_for_ngc_images.outputs.IMAGES }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Check for NGC PyTorch images
-        id: check_for_ngc_images
-        run: |
-          bash ./.github/scripts/check_for_ngc_images.sh
-          echo "IMAGES=$(cat ngc_images.json| jq -cr)" >> $GITHUB_OUTPUT
-
   build-wheels:
-    needs: [get_version, check_for_ngc_images]
+    needs: [get_version]
     uses: ./.github/workflows/_build_in_container.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        container-image: ${{ fromJson(needs.check_for_ngc_images.outputs.images) }}
     with:
       runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
-      container-image: ${{ matrix.container-image }}
+      container-image: ${{ inputs.container-image || 'nvcr.io/nvidia/pytorch:25.06-py3' }}
       upload-to-release: ${{ inputs.upload-to-release || false }}
       release-version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/build_in_container_scheduled.yml
+++ b/.github/workflows/build_in_container_scheduled.yml
@@ -1,0 +1,48 @@
+name: Build wheels in a container (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.compute.outputs.RUNNERS }}
+      container-images: ${{ steps.compute.outputs.IMAGES }}
+      release-versions: ${{ steps.compute.outputs.RELEASES }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for NGC PyTorch images
+        run: bash ./.github/scripts/check_for_ngc_images.sh
+
+      - name: Check for upstream releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_REPO: Dao-AILab/causal-conv1d
+        run: bash ./.github/scripts/check_for_releases.sh
+
+      - name: Build matrix outputs
+        id: compute
+        run: |
+          echo "RUNNERS=$(jq -cn '["ubuntu-22.04","ubuntu-22.04-arm"]')" | tee -a "$GITHUB_OUTPUT"
+          echo "IMAGES=$(jq -cr . ngc_images.json)" | tee -a "$GITHUB_OUTPUT"
+          echo "RELEASES=$(jq -cr . releases.json)" | tee -a "$GITHUB_OUTPUT"
+
+  build-wheels:
+    needs: [compute_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.compute_matrix.outputs.runners) }}
+        container-image: ${{ fromJson(needs.compute_matrix.outputs.container-images) }}
+        release-version: ${{ fromJson(needs.compute_matrix.outputs.release-versions) }}
+    uses: ./.github/workflows/_build_in_container.yml
+    with:
+      runs-on: ${{ matrix.runner }}
+      container-image: ${{ matrix.container-image }}
+      upload-to-release: false
+      release-version: ${{ matrix.release-version }}

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ def get_platform():
     Returns the platform name as used in wheel filenames.
     """
     if sys.platform.startswith("linux"):
+        machine = platform.machine().lower()
+        if machine in ("aarch64", "arm64"):
+            return "linux_aarch64"
         return "linux_x86_64"
     elif sys.platform == "darwin":
         mac_version = ".".join(platform.mac_ver()[0].split(".")[:2])


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Adds a weekly scheduled wheel-build pipeline that fans out across:

- **runners**: `ubuntu-22.04`, `ubuntu-22.04-arm`
- **container images**: last 7 `nvcr.io/nvidia/pytorch:YY.MM-py3` images (existing `check_for_ngc_images.sh`)
- **release versions**: last 3 stable upstream tags (new `check_for_releases.sh`, hits `Dao-AILab/causal-conv1d`)

Total: up to **42 jobs** per scheduled run.

Triggers on the new workflow:
- `schedule`: cron `0 6 * * 1` (Mondays 06:00 UTC)
- `workflow_dispatch`: manual run, full matrix

## Bug fix in `build_in_container.yml`

The existing workflow always fanned out across all 7 NGC images, even on `push` and `workflow_dispatch`, ignoring the `container-image` input. Removed the inline matrix so non-scheduled triggers now run a **single** config from inputs/defaults — matching the mamba workflow's shape. The fan-out lives in the new `*_scheduled.yml` only.

## Example matrix dimensions

```json
{
  "runner":          ["ubuntu-22.04", "ubuntu-22.04-arm"],
  "container-image": ["nvcr.io/nvidia/pytorch:26.04-py3", "..."],
  "release-version": ["v1.6.1.post4", "v1.6.1.post3", "v1.6.1.post2"]
}
```

</details>