### PR TITLE
add ROCm/HIP build instructions for AMD GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,26 @@ import torch.nn.functional as F
 F.conv1d(x, weight.unsqueeze(1), bias, padding=width - 1, groups=dim)[..., :seqlen]
 ```
 
-## Additional Prerequisites for AMD cards
+## AMD ROCm/HIP support
 
-### Patching ROCm
+causal-conv1d supports AMD GPUs via ROCm/HIP (ROCm 6.1+).
 
-If you are on ROCm 6.0, run the following steps to avoid errors during compilation. This is not required for ROCm 6.1 onwards.
+### Building from source
+
+```bash
+# Set your GPU architecture
+export HIP_ARCHITECTURES=gfx1201  # e.g., gfx1100, gfx1101, gfx1201
+
+# --no-build-isolation ensures the build uses your existing ROCm PyTorch
+# instead of pulling the default CUDA PyTorch from PyPI
+CAUSAL_CONV1D_FORCE_BUILD=TRUE pip install --no-build-isolation -e .
+```
+
+`--no-build-isolation` is required because pip's default build isolation installs a CUDA-only PyTorch, which causes the HIP detection to fail.
+
+### Patching ROCm 6.0
+
+If you are on ROCm 6.0, apply the following patch before building. This is not required for ROCm 6.1 onwards.
 
 1. Locate your ROCm installation directory. This is typically found at `/opt/rocm/`, but may vary depending on your installation.
 


### PR DESCRIPTION
## Summary

Add build instructions for AMD GPUs via ROCm/HIP. The project already
supports HIP (setup.py detects torch.version.hip and configures HIP
compile flags), but the README only documents a ROCm 6.0 patch without
explaining how to build on AMD hardware.

This addresses #99.

## Test environment

- GPU: AMD Radeon R9700 Pro (gfx1201, RDNA 4), 32 GB VRAM
- OS: Ubuntu 24.04, kernel 6.17.0-20-generic
- ROCm: 7.2.3 (container: rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.9.1)
- PyTorch: 2.9.1+rocm7.2.3

## Build steps

```bash
docker run -it --device /dev/kfd --device /dev/dri \
  -e ROCBLAS_USE_HIPBLASLT=0 -e HIP_VISIBLE_DEVICES=0 \
  rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.9.1

# inside container
git clone https://github.com/Dao-AILab/causal-conv1d.git
cd causal-conv1d
pip install einops
HIP_ARCHITECTURES=gfx1201 CAUSAL_CONV1D_FORCE_BUILD=TRUE \
  pip install --no-build-isolation -e .
```
## Test results
### Functional test:
```python
import torch
from causal_conv1d import causal_conv1d_fn
x = torch.randn(2, 64, 128, device="cuda", dtype=torch.float16)
weight = torch.randn(64, 4, device="cuda", dtype=torch.float16)
out = causal_conv1d_fn(x, weight)
print(out.shape, torch.isnan(out).any(), torch.isinf(out).any())
# torch.Size([2, 64, 128]) tensor(False) tensor(False)
```
### Full test suite:
```bash
python3 -m pytest tests/test_causal_conv1d.py -v
================ 9412 passed, 3888 skipped in 166.05s (0:02:46) ======
```