### PR TITLE
Expand publish matrix for PyTorch 2.11 and 2.12

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -108,6 +108,8 @@ jobs:
               '2.8': [126, 128, 129], \
               '2.9': [126, 128, 130], \
               '2.10': [126, 128, 130], \
+              '2.11': [126, 128, 130], \
+              '2.12': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,8 +40,8 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0"]
-        cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
+        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.0"]
+        cuda-version: ["11.8.0", "12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
@@ -55,6 +55,10 @@ jobs:
             cuda-version: "11.8.0"
           - torch-version: "2.10.0"
             cuda-version: "11.8.0"
+          - torch-version: "2.11.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.0"
+            cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
             cuda-version: "13.0.1"
@@ -62,6 +66,19 @@ jobs:
             cuda-version: "13.0.1"
           - torch-version: "2.8.0"
             cuda-version: "13.0.1"
+          # CUDA 13.2 wheels are only available for PyTorch 2.12
+          - torch-version: "2.6.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.7.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.8.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.9.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.10.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.11.0"
+            cuda-version: "13.2.0"
           # No aarch64 PyTorch wheels for 2.6.0, or 2.7.1+cu118
           - torch-version: "2.6.0"
             os: ubuntu-22.04-arm
@@ -76,6 +93,10 @@ jobs:
           - torch-version: "2.9.1"
             cxx11_abi: "FALSE"
           - torch-version: "2.10.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.11.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml


### PR DESCRIPTION
This updates the release workflows to publish wheels for PyTorch 2.11 and 2.12, and aligns the reusable build workflow with the CUDA wheel variants those PyTorch releases actually publish. The matrix now includes the new supported combinations while excluding unsupported torch/CUDA pairs.

- **Publish matrix**
  - Adds `2.11.0` and `2.12.0` to `publish.yaml`
  - Adds CUDA `13.2.0` for the PyTorch 2.12 wheel line

- **Compatibility rules**
  - Excludes `11.8` for PyTorch `2.11` and `2.12`
  - Excludes `13.2` for all versions before `2.12`
  - Extends the existing `cxx11_abi: FALSE` exclusion to `2.11+`, matching the newer pip wheel behavior

- **Reusable build workflow**
  - Extends `_build.yml` CUDA wheel selection logic:
    - PyTorch `2.11` → `cu126`, `cu128`, `cu130`
    - PyTorch `2.12` → `cu126`, `cu130`, `cu132`

```yaml
torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.0"]
cuda-version: ["11.8.0", "12.9.1", "13.0.1", "13.2.0"]
```