### PR TITLE
setup.py: fix NameError for bare_metal_version when CUDA_HOME is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,27 +176,27 @@ if not SKIP_CUDA_BUILD:
                     "Note: make sure nvcc has a supported version by running nvcc -V."
                 )
 
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_75,code=sm_75")
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_80,code=sm_80")
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_87,code=sm_87")
-        if bare_metal_version >= Version("11.8"):
             cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_90,code=sm_90")
-        if bare_metal_version >= Version("12.8"):
+            cc_flag.append("arch=compute_75,code=sm_75")
             cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_100,code=sm_100")
+            cc_flag.append("arch=compute_80,code=sm_80")
             cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_120,code=sm_120")
-        if bare_metal_version >= Version("13.0"):
-            cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_103,code=sm_103")
-            cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_110,code=sm_110")
-            cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_121,code=sm_121")
+            cc_flag.append("arch=compute_87,code=sm_87")
+            if bare_metal_version >= Version("11.8"):
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_90,code=sm_90")
+            if bare_metal_version >= Version("12.8"):
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_100,code=sm_100")
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_120,code=sm_120")
+            if bare_metal_version >= Version("13.0"):
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_103,code=sm_103")
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_110,code=sm_110")
+                cc_flag.append("-gencode")
+                cc_flag.append("arch=compute_121,code=sm_121")
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
Fixes #108.

## Problem
`setup.py` assigns `bare_metal_version` only inside the `if CUDA_HOME is not None:` guard, but the `-gencode` arch-flag block reads it *outside* that guard. When CUDA_HOME is not detected (no nvcc, or Windows where CUDA_HOME is unset), the install crashes with:

```
NameError: name 'bare_metal_version' is not defined
```

instead of the intended warning path from `check_if_cuda_home_none`. This affects both reporters in #108: the no-nvcc container case and @megakoresh's Windows case (nvcc present but CUDA_HOME unset).

## Fix
Move the arch-flag block inside the `if CUDA_HOME is not None:` guard. The `-gencode` flags are only meaningful when a CUDA toolchain is present, so gating them there is correct and keeps the no-CUDA path warning-only rather than crashing.

## Verification
Simulated the branch with `CUDA_HOME=None`: the original code raises `NameError`; the patched code returns cleanly with no arch flags. With CUDA_HOME set, all arch flags are still appended as before (no behavior change for real builds).

A clearer 'install a prebuilt wheel' error for users actively building without nvcc could be a nice follow-up, but is left out here to avoid changing the existing warn-not-raise policy.