### PR TITLE
fix: trigger release workflow on tag push, not create event

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -110,6 +110,7 @@ jobs:
               '2.10': [126, 128, 130], \
               '2.11': [126, 128, 130], \
               '2.12': [126, 130, 132], \
+              '2.13': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -108,6 +108,8 @@ jobs:
               '2.8': [126, 128, 129], \
               '2.9': [126, 128, 130], \
               '2.10': [126, 128, 130], \
+              '2.11': [126, 128, 130], \
+              '2.12': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -110,7 +110,6 @@ jobs:
               '2.10': [126, 128, 130], \
               '2.11': [126, 128, 130], \
               '2.12': [126, 130, 132], \
-              '2.13': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -108,6 +108,9 @@ jobs:
               '2.8': [126, 128, 129], \
               '2.9': [126, 128, 130], \
               '2.10': [126, 128, 130], \
+              '2.11': [126, 128, 130], \
+              '2.12': [126, 130, 132], \
+              '2.13': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -108,8 +108,6 @@ jobs:
               '2.8': [126, 128, 129], \
               '2.9': [126, 128, 130], \
               '2.10': [126, 128, 130], \
-              '2.11': [126, 128, 130], \
-              '2.12': [126, 130, 132], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@
 name: Build wheels and deploy
 
 on:
-  create:
+  push:
     tags:
       - v*
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.12", "3.13"]
-        torch-version: ["2.11.0", "2.12.0"]
+        torch-version: ["2.11.0", "2.12.0", "2.12.1", "2.13.0"]
         cuda-version: ["12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
@@ -61,6 +61,10 @@ jobs:
           - torch-version: "2.11.0"
             cuda-version: "11.8.0"
           - torch-version: "2.12.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.1"
+            cuda-version: "11.8.0"
+          - torch-version: "2.13.0"
             cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
@@ -100,6 +104,10 @@ jobs:
           - torch-version: "2.11.0"
             cxx11_abi: "FALSE"
           - torch-version: "2.12.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.1"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.13.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,8 +40,8 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0"]
-        cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
+        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.0"]
+        cuda-version: ["11.8.0", "12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
@@ -55,6 +55,10 @@ jobs:
             cuda-version: "11.8.0"
           - torch-version: "2.10.0"
             cuda-version: "11.8.0"
+          - torch-version: "2.11.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.0"
+            cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
             cuda-version: "13.0.1"
@@ -62,6 +66,19 @@ jobs:
             cuda-version: "13.0.1"
           - torch-version: "2.8.0"
             cuda-version: "13.0.1"
+          # CUDA 13.2 wheels are only available for PyTorch 2.12
+          - torch-version: "2.6.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.7.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.8.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.9.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.10.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.11.0"
+            cuda-version: "13.2.0"
           # No aarch64 PyTorch wheels for 2.6.0, or 2.7.1+cu118
           - torch-version: "2.6.0"
             os: ubuntu-22.04-arm
@@ -76,6 +93,10 @@ jobs:
           - torch-version: "2.9.1"
             cxx11_abi: "FALSE"
           - torch-version: "2.10.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.11.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+
 jobs:
   setup_release:
     name: Create Release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,9 +42,9 @@ jobs:
         # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.0"]
-        cuda-version: ["11.8.0", "12.9.1", "13.0.1", "13.2.0"]
+        python-version: ["3.12", "3.13"]
+        torch-version: ["2.11.0", "2.12.0"]
+        cuda-version: ["12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.12", "3.13"]
-        torch-version: ["2.11.0", "2.12.0", "2.12.1", "2.13.0"]
+        torch-version: ["2.11.0", "2.12.0"]
         cuda-version: ["12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
@@ -61,10 +61,6 @@ jobs:
           - torch-version: "2.11.0"
             cuda-version: "11.8.0"
           - torch-version: "2.12.0"
-            cuda-version: "11.8.0"
-          - torch-version: "2.12.1"
-            cuda-version: "11.8.0"
-          - torch-version: "2.13.0"
             cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
@@ -104,10 +100,6 @@ jobs:
           - torch-version: "2.11.0"
             cxx11_abi: "FALSE"
           - torch-version: "2.12.0"
-            cxx11_abi: "FALSE"
-          - torch-version: "2.12.1"
-            cxx11_abi: "FALSE"
-          - torch-version: "2.13.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,9 +12,6 @@ on:
     tags:
       - v*
 
-permissions:
-  contents: write
-
 jobs:
   setup_release:
     name: Create Release
@@ -42,9 +39,9 @@ jobs:
         # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
-        python-version: ["3.12", "3.13"]
-        torch-version: ["2.11.0", "2.12.0"]
-        cuda-version: ["12.9.1", "13.0.1", "13.2.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0"]
+        cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
@@ -58,10 +55,6 @@ jobs:
             cuda-version: "11.8.0"
           - torch-version: "2.10.0"
             cuda-version: "11.8.0"
-          - torch-version: "2.11.0"
-            cuda-version: "11.8.0"
-          - torch-version: "2.12.0"
-            cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
             cuda-version: "13.0.1"
@@ -69,19 +62,6 @@ jobs:
             cuda-version: "13.0.1"
           - torch-version: "2.8.0"
             cuda-version: "13.0.1"
-          # CUDA 13.2 wheels are only available for PyTorch 2.12
-          - torch-version: "2.6.0"
-            cuda-version: "13.2.0"
-          - torch-version: "2.7.1"
-            cuda-version: "13.2.0"
-          - torch-version: "2.8.0"
-            cuda-version: "13.2.0"
-          - torch-version: "2.9.1"
-            cuda-version: "13.2.0"
-          - torch-version: "2.10.0"
-            cuda-version: "13.2.0"
-          - torch-version: "2.11.0"
-            cuda-version: "13.2.0"
           # No aarch64 PyTorch wheels for 2.6.0, or 2.7.1+cu118
           - torch-version: "2.6.0"
             os: ubuntu-22.04-arm
@@ -96,10 +76,6 @@ jobs:
           - torch-version: "2.9.1"
             cxx11_abi: "FALSE"
           - torch-version: "2.10.0"
-            cxx11_abi: "FALSE"
-          - torch-version: "2.11.0"
-            cxx11_abi: "FALSE"
-          - torch-version: "2.12.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+
 jobs:
   setup_release:
     name: Create Release
@@ -39,9 +42,9 @@ jobs:
         # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0"]
-        cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
+        python-version: ["3.12", "3.13"]
+        torch-version: ["2.11.0", "2.12.0", "2.12.1", "2.13.0"]
+        cuda-version: ["12.9.1", "13.0.1", "13.2.0"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
@@ -55,6 +58,14 @@ jobs:
             cuda-version: "11.8.0"
           - torch-version: "2.10.0"
             cuda-version: "11.8.0"
+          - torch-version: "2.11.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.1"
+            cuda-version: "11.8.0"
+          - torch-version: "2.13.0"
+            cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
             cuda-version: "13.0.1"
@@ -62,6 +73,19 @@ jobs:
             cuda-version: "13.0.1"
           - torch-version: "2.8.0"
             cuda-version: "13.0.1"
+          # CUDA 13.2 wheels are only available for PyTorch 2.12
+          - torch-version: "2.6.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.7.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.8.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.9.1"
+            cuda-version: "13.2.0"
+          - torch-version: "2.10.0"
+            cuda-version: "13.2.0"
+          - torch-version: "2.11.0"
+            cuda-version: "13.2.0"
           # No aarch64 PyTorch wheels for 2.6.0, or 2.7.1+cu118
           - torch-version: "2.6.0"
             os: ubuntu-22.04-arm
@@ -76,6 +100,14 @@ jobs:
           - torch-version: "2.9.1"
             cxx11_abi: "FALSE"
           - torch-version: "2.10.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.11.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.1"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.13.0"
             cxx11_abi: "FALSE"
 
     uses: ./.github/workflows/_build.yml

--- a/causal_conv1d/causal_conv1d_varlen.py
+++ b/causal_conv1d/causal_conv1d_varlen.py
@@ -17,16 +17,24 @@ def _causal_conv1d_varlen_states(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr
 ):
-    batch_idx = tl.program_id(2)
+    # Pointer offsets must be computed in int64. `rows * stride_x_seqlen` reaches
+    # total_tokens * stride_x_seqlen, and X is typically a view into a wider fused
+    # projection buffer (so stride_x_seqlen is that buffer's row width, not `dim`),
+    # which overflows int32 long before the tensor itself is unreasonable. Triton
+    # defaults program ids, tl.arange and int32 loads to int32, so widening must be
+    # explicit; `rows`/`cols` then propagate int64 through the address arithmetic.
+    batch_idx = tl.program_id(2).to(tl.int64)
+    pid_m = tl.program_id(1).to(tl.int64)
+    pid_n = tl.program_id(0).to(tl.int64)
     STATES += batch_idx * stride_states_batch
-    end_idx = tl.load(CU_SEQLENS + batch_idx + 1)
-    start_idx = tl.maximum(tl.load(CU_SEQLENS + batch_idx), end_idx - state_len)
-    rows = end_idx - (tl.program_id(1) + 1) * BLOCK_M + tl.arange(0, BLOCK_M)
-    cols = tl.program_id(0) * BLOCK_N + tl.arange(0, BLOCK_N)
+    end_idx = tl.load(CU_SEQLENS + batch_idx + 1).to(tl.int64)
+    start_idx = tl.maximum(tl.load(CU_SEQLENS + batch_idx).to(tl.int64), end_idx - state_len)
+    rows = end_idx - (pid_m + 1) * BLOCK_M + tl.arange(0, BLOCK_M)
+    cols = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     x = tl.load(X + rows[:, None] * stride_x_seqlen + cols[None, :] * stride_x_dim,
                 mask=(rows[:, None] >= start_idx) & (cols[None, :] < dim),
                 other=0)
-    rows_states = state_len - (tl.program_id(1) + 1) * BLOCK_M + tl.arange(0, BLOCK_M)
+    rows_states = state_len - (pid_m + 1) * BLOCK_M + tl.arange(0, BLOCK_M)
     tl.store(STATES + rows_states[:, None] * stride_states_seqlen + cols[None, :] * stride_states_dim,
              x,
              mask=(rows_states[:, None] >= 0) & (cols[None, :] < dim))

--- a/csrc/causal_conv1d.h
+++ b/csrc/causal_conv1d.h
@@ -4,10 +4,19 @@
 
 #pragma once
 
+#include <cstdint>
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct ConvParamsBase {
-    using index_t = uint32_t;
+    // Element offsets are accumulated in this type. It must be wide enough to hold
+    // the largest flat offset any kernel touches, which for a tensor that is a view
+    // into a larger buffer (e.g. the xBC slice of mamba2's fused in_proj output) is
+    // roughly batch * seqlen * <the parent buffer's row width>, not the size of the
+    // view itself. A 32-bit type wraps at 2^32 elements; because the wrapped offset
+    // still lands inside the same allocation, that corrupts results silently instead
+    // of faulting, so it must stay 64-bit.
+    using index_t = int64_t;
 
     int batch, dim, seqlen, width;
     bool silu_activation;

--- a/csrc/causal_conv1d_bwd.cu
+++ b/csrc/causal_conv1d_bwd.cu
@@ -362,8 +362,9 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
         + (chunk_l_id * kChunkSizeL + l_idx) * params.dx_l_stride + chunk_c_id * kChunkSizeC + c_idx * kNElts;
     float *dweight = reinterpret_cast<float *>(params.dweight_ptr)
         + chunk_c_id * kChunkSizeC * params.dweight_c_stride;
+    // batch_id and params.seqlen are both int, so widen before multiplying.
     int *seq_idx = !kHasSeqIdx ? nullptr : reinterpret_cast<int *>(params.seq_idx_ptr)
-        + batch_id * params.seqlen + chunk_l_id * kChunkSizeL;
+        + static_cast<int64_t>(batch_id) * params.seqlen + chunk_l_id * kChunkSizeL;
     input_t *initial_states = params.initial_states_ptr == nullptr || chunk_l_id > 0 ? nullptr
         : reinterpret_cast<input_t *>(params.initial_states_ptr) + batch_id * params.initial_states_batch_stride + l_idx * params.initial_states_l_stride + chunk_c_id * kChunkSizeC + c_idx * kNElts;
     input_t *dinitial_states = params.dinitial_states_ptr == nullptr || chunk_l_id > 0 ? nullptr
@@ -510,8 +511,9 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
         if (col_idx == 0 && chunk_c_id * kChunkSizeC + row_idx < params.dim) {
             if constexpr (kDeterministic) {
                 float *dbias_ws = reinterpret_cast<float *>(params.dbias_workspace_ptr);
+                // chunk_l_id and params.dim are both int, so widen before multiplying.
                 dbias_ws[batch_id * params.dbias_workspace_batch_stride
-                       + chunk_l_id * params.dim
+                       + static_cast<int64_t>(chunk_l_id) * params.dim
                        + (chunk_c_id * kChunkSizeC + row_idx)] = dbias_val;
             } else {
                 atomicAdd(&reinterpret_cast<float *>(params.dbias_ptr)[chunk_c_id * kChunkSizeC + row_idx], dbias_val);

--- a/csrc/causal_conv1d_fwd.cu
+++ b/csrc/causal_conv1d_fwd.cu
@@ -232,8 +232,9 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
         + chunk_c_id * kChunkSizeC * params.weight_c_stride;
     input_t *out = reinterpret_cast<input_t *>(params.out_ptr) + batch_id * params.out_batch_stride
         + (chunk_l_id * kChunkSizeL + l_idx) * params.out_l_stride + chunk_c_id * kChunkSizeC + c_idx * kNElts;
+    // batch_id and params.seqlen are both int, so widen before multiplying.
     int *seq_idx = !kHasSeqIdx ? nullptr : reinterpret_cast<int *>(params.seq_idx_ptr)
-        + batch_id * params.seqlen + chunk_l_id * kChunkSizeL;
+        + static_cast<int64_t>(batch_id) * params.seqlen + chunk_l_id * kChunkSizeL;
     input_t *initial_states = params.initial_states_ptr == nullptr || chunk_l_id > 0 ? nullptr
         : reinterpret_cast<input_t *>(params.initial_states_ptr) + batch_id * params.initial_states_batch_stride + l_idx * params.initial_states_l_stride + chunk_c_id * kChunkSizeC + c_idx * kNElts;
     // The last L-chunk will also have enough info to write to final states, since it also contain a few x values


### PR DESCRIPTION
## Summary
- The `create` event does not support `tags`/`branches` filters, so `on: create: tags: [v*]` was silently ignored and this workflow fired on every branch or tag creation, not just version tags.
- Switches the trigger to `on: push: tags: [v*]`, which does support tag filtering, so the workflow only runs on actual version-tag pushes.

## Test plan
- [ ] Push a tag matching `v*` and confirm the release workflow triggers
- [ ] Create a new branch and confirm the release workflow does NOT trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)