### PR TITLE
Fix seq_idx tail bounds in channel-last forward

### DIFF
--- a/csrc/causal_conv1d_fwd.cu
+++ b/csrc/causal_conv1d_fwd.cu
@@ -305,7 +305,11 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
     if constexpr (kHasSeqIdx) {
         #pragma unroll
         for (int i = 0; i < kWidth - 1 + kLPerThread; ++i) {
-            seq_idx_thread[i] = chunk_l_id * kChunkSizeL + col_idx * kLPerThread + i - (kWidth - 1) >= 0 ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)] : -1;
+            const int l_idx = chunk_l_id * kChunkSizeL + col_idx * kLPerThread
+                + i - (kWidth - 1);
+            seq_idx_thread[i] = l_idx >= 0 && l_idx < params.seqlen
+                ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)]
+                : -1;
         }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,8 @@ if not SKIP_CUDA_BUILD:
         cc_flag.append("arch=compute_87,code=sm_87")
         if bare_metal_version >= Version("11.8"):
             cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_89,code=sm_89")
+            cc_flag.append("-gencode")
             cc_flag.append("arch=compute_90,code=sm_90")
         if bare_metal_version >= Version("12.8"):
             cc_flag.append("-gencode")

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -407,7 +407,7 @@ def test_causal_conv1d_race_condition(seqlen, width, has_bias, silu_activation, 
 @pytest.mark.parametrize("width", [2, 3, 4])
 # @pytest.mark.parametrize('width', [2])
 @pytest.mark.parametrize(
-    "seqlen", [8, 16, 32, 64, 128, 151, 256, 372, 512, 784, 1024, 1134, 2048, 4096]
+    "seqlen", [8, 16, 32, 63, 64, 65, 127, 128, 129, 151, 256, 257, 372, 512, 784, 1024, 1134, 2048, 4096]
 )
 # @pytest.mark.parametrize('seqlen', [8, 16, 32, 64, 128, 256, 512, 784, 1024, 2048, 4096])
 # @pytest.mark.parametrize('seqlen', [2048])


### PR DESCRIPTION
## Summary

This PR fixes an out-of-bounds `seq_idx` read in the channel-last causal convolution forward kernel and adds native CUDA support for Ada GPUs (`sm_89`).

## Problem

In `causal_conv1d_channellast_fwd_kernel`, `seq_idx` loads checked that the logical sequence index was non-negative, but did not check that it was smaller than `params.seqlen`.

For a sequence length that does not fill the final kernel chunk, threads processing the tail could read past the logical end of `seq_idx`. The backward kernel already performs both bounds checks.

## Changes

- Guard channel-last forward `seq_idx` reads with:

  ```cpp
  l_idx >= 0 && l_idx < params.seqlen
  ```

- Add regression coverage around kernel chunk boundaries:

  - 63, 64, 65
  - 127, 128, 129
  - 256, 257

- Add `sm_89` to the CUDA build targets for Ada GPUs such as RTX 4090 and L40.

## Validation

Tested with:

- PyTorch 2.8.0
- CUDA 12.8
- RTX 4090 (`sm_89`)
- FP16/BF16 channel-last inputs
- `seq_idx` containing multiple packed variable-length 1D sequences
- Forward and backward passes
- Sequence lengths around CUDA kernel chunk boundaries

Results across 51 forward/backward cases:

- Maximum output difference: `0`
- Maximum input-gradient difference: `2.33e-10`
- Maximum weight-gradient difference: `2.86e-6`
- Compute Sanitizer: `ERROR SUMMARY: 0 errors`

The small weight-gradient difference is caused by the BF16 accumulation order.

## Performance

The table reports causal-conv1d forward and backward time. Input shapes use the public API layout `x: (batch, dim, seqlen)`. Segment lengths describe the packed 1D sequences encoded by `seq_idx`.

| Input shape | Packed segment lengths | Native `seq_idx` | Physical gap padding |
|---|---|---:|---:|
| `(196, 2304, 32)` | `[16, 16]` | 3.48 ms | 4.23 ms |
| `(59, 2304, 160)` | `[8, 12, 16, 20, 24] x 2` | 2.27 ms | 4.35 ms |
| `(59, 2304, 128)` | `[2] x 64` | 2.02 ms | 4.57 ms |

The fixed native `seq_idx` path avoids inserting zero-valued elements between packed 1D sequences and removes the associated scatter/gather allocations.
