### PR TITLE
Support initial states with packed sequences

### DIFF
--- a/causal_conv1d/causal_conv1d_interface.py
+++ b/causal_conv1d/causal_conv1d_interface.py
@@ -26,9 +26,6 @@ class CausalConv1dFn(torch.autograd.Function):
         bias = bias.contiguous() if bias is not None else None
         if seq_idx is not None:
             assert (
-                initial_states is None
-            ), "initial_states must be None if seq_idx is not None"
-            assert (
                 not return_final_states
             ), "If seq_idx is not None, we don't return final_states_out"
         seq_idx = seq_idx.contiguous() if seq_idx is not None else None
@@ -137,11 +134,13 @@ def causal_conv1d_ref(
     return_final_states=False,
     final_states_out=None,
     activation=None,
+    seq_idx=None,
 ):
     """
     x: (batch, dim, seqlen)
     weight: (dim, width)
     bias: (dim,)
+    seq_idx: (batch, seqlen)
     initial_states: (batch, dim, width - 1)
     final_states_out: (batch, dim, width - 1)
 
@@ -153,7 +152,27 @@ def causal_conv1d_ref(
     x = x.to(weight.dtype)
     seqlen = x.shape[-1]
     dim, width = weight.shape
-    if initial_states is None:
+    if seq_idx is not None:
+        assert seq_idx.shape == (x.shape[0], seqlen)
+        assert not return_final_states, "seq_idx does not support return_final_states"
+        if initial_states is None:
+            x = F.pad(x, (width - 1, 0))
+            initial_state_seq_idx = seq_idx.new_full((x.shape[0], width - 1), -1)
+        else:
+            x = torch.cat([initial_states, x], dim=-1)
+            initial_state_seq_idx = seq_idx[:, :1].expand(-1, width - 1)
+        seq_idx_with_state = torch.cat([initial_state_seq_idx, seq_idx], dim=-1)
+        x_windows = x.unfold(dimension=-1, size=width, step=1)
+        seq_idx_windows = seq_idx_with_state.unfold(dimension=-1, size=width, step=1)
+        same_sequence = seq_idx_windows == seq_idx.unsqueeze(-1)
+        out = torch.sum(
+            x_windows * same_sequence.unsqueeze(1) * weight.view(1, dim, 1, width),
+            dim=-1,
+        )
+        if bias is not None:
+            out = out + bias.view(1, dim, 1)
+        out = out.masked_fill((seq_idx < 0).unsqueeze(1), 0.0)
+    elif initial_states is None:
         out = F.conv1d(x, weight.unsqueeze(1), bias, padding=width - 1, groups=dim)
     else:
         x = torch.cat([initial_states, x], dim=-1)

--- a/csrc/causal_conv1d_bwd.cu
+++ b/csrc/causal_conv1d_bwd.cu
@@ -448,10 +448,13 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
 
     int seq_idx_thread[kWidth - 1 + kLPerThread + kWidth - 1];
     if constexpr (kHasSeqIdx) {
+        const int initial_state_seq_idx = initial_states == nullptr ? -1 : seq_idx[0];
         #pragma unroll
         for (int i = 0; i < kWidth - 1 + kLPerThread + kWidth - 1; ++i) {
             const int l_idx = chunk_l_id * kChunkSizeL + col_idx * kLPerThread + i - (kWidth - 1);
-            seq_idx_thread[i] = l_idx >= 0 && l_idx < params.seqlen ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)] : -1;
+            seq_idx_thread[i] = l_idx >= 0 && l_idx < params.seqlen
+                ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)]
+                : l_idx < 0 ? initial_state_seq_idx : -1;
         }
     }
 
@@ -548,7 +551,15 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
         for (int i = 0; i < kWidth - 1; ++i) {
             #pragma unroll
             for (int w = 0; w < kWidth; ++w) {
-                dxinit_vals[i] += i + w - (kWidth - 1) >= 0 ? weight_vals[kWidth - 1 - w] * dout_vals[i + w - (kWidth - 1)] : 0.f;
+                if (i + w - (kWidth - 1) >= 0) {
+                    if constexpr (!kHasSeqIdx) {
+                        dxinit_vals[i] += weight_vals[kWidth - 1 - w] * dout_vals[i + w - (kWidth - 1)];
+                    } else {
+                        dxinit_vals[i] += seq_idx_thread[i] == seq_idx_thread[i + w]
+                            ? weight_vals[kWidth - 1 - w] * dout_vals[i + w - (kWidth - 1)]
+                            : 0.f;
+                    }
+                }
             }
             // chunk_l_id must be 0 because dinitial_states != nullptr
             // if (dfinal_states != nullptr) {

--- a/csrc/causal_conv1d_fwd.cu
+++ b/csrc/causal_conv1d_fwd.cu
@@ -303,9 +303,13 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
     }
     int seq_idx_thread[kWidth - 1 + kLPerThread];
     if constexpr (kHasSeqIdx) {
+        const int initial_state_seq_idx = initial_states == nullptr ? -1 : seq_idx[0];
         #pragma unroll
         for (int i = 0; i < kWidth - 1 + kLPerThread; ++i) {
-            seq_idx_thread[i] = chunk_l_id * kChunkSizeL + col_idx * kLPerThread + i - (kWidth - 1) >= 0 ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)] : -1;
+            const int l_idx = chunk_l_id * kChunkSizeL + col_idx * kLPerThread + i - (kWidth - 1);
+            seq_idx_thread[i] = l_idx >= 0 && l_idx < params.seqlen
+                ? seq_idx[col_idx * kLPerThread + i - (kWidth - 1)]
+                : l_idx < 0 ? initial_state_seq_idx : -1;
         }
     }
 

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -471,6 +471,160 @@ def test_causal_conv1d_varlen(dim, seqlen, width, has_bias, silu_activation, ity
     if has_bias:
         assert torch.allclose(bias.grad, bias_ref.grad, rtol=rtolw, atol=atolw)
 
+
+def test_causal_conv1d_ref_varlen_initial_states():
+    device = "cuda"
+    rtol, atol = 3e-4, 1e-3
+    torch.random.manual_seed(0)
+    batch, dim, seqlen, width = 2, 8, 7, 4
+    x = torch.randn(batch, dim, seqlen, device=device, dtype=torch.float32)
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32)
+    bias = torch.randn(dim, device=device, dtype=torch.float32)
+    initial_states = torch.randn(
+        batch, dim, width - 1, device=device, dtype=torch.float32
+    )
+    seq_idx = torch.tensor(
+        [[3, 5, 5, 5, 9, 9, 9], [4, 4, 6, 6, 6, 6, 8]],
+        device=device,
+        dtype=torch.int32,
+    )
+
+    out = causal_conv1d_ref(
+        x,
+        weight,
+        bias,
+        initial_states=initial_states,
+        activation="silu",
+        seq_idx=seq_idx,
+    )
+    out_ref = []
+    for b, split_sizes in enumerate(([1, 3, 3], [2, 4, 1])):
+        out_ref.append(
+            torch.cat(
+                [
+                    causal_conv1d_ref(
+                        x_s,
+                        weight,
+                        bias,
+                        initial_states=initial_states[[b]] if i == 0 else None,
+                        activation="silu",
+                    )
+                    for i, x_s in enumerate(
+                        torch.split(x[[b]], split_sizes, dim=-1)
+                    )
+                ],
+                dim=-1,
+            )
+        )
+    out_ref = torch.cat(out_ref, dim=0)
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("width", [2, 3, 4])
+@pytest.mark.parametrize("seqlen", [8, 151])
+def test_causal_conv1d_varlen_initial_states(
+    seqlen, width, has_bias, silu_activation, itype
+):
+    device = "cuda"
+    rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    rtolw, atolw = 1e-3, 1e-3
+    torch.random.manual_seed(seqlen + width)
+    batch, dim = 2, 64
+    x = (
+        torch.randn(batch, seqlen, dim + 16, device=device, dtype=itype)[
+            :, :, :dim
+        ]
+        .transpose(1, 2)
+        .requires_grad_()
+    )
+    weight = torch.randn(
+        dim, width, device=device, dtype=torch.float32, requires_grad=True
+    )
+    bias = (
+        torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True)
+        if has_bias
+        else None
+    )
+    initial_states = (
+        torch.randn(batch, width - 1, dim, device=device, dtype=itype)
+        .transpose(1, 2)
+        .requires_grad_()
+    )
+    first_fragment_lengths = [max(1, width - 2), width]
+    seq_idx = torch.stack(
+        [
+            torch.cat(
+                [
+                    torch.full(
+                        (first_fragment_len,),
+                        2 * b + 3,
+                        device=device,
+                        dtype=torch.int32,
+                    ),
+                    torch.full(
+                        (seqlen - first_fragment_len,),
+                        2 * b + 4,
+                        device=device,
+                        dtype=torch.int32,
+                    ),
+                ]
+            )
+            for b, first_fragment_len in enumerate(first_fragment_lengths)
+        ]
+    )
+
+    x_ref = x.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+    bias_ref = bias.detach().clone().requires_grad_() if bias is not None else None
+    initial_states_ref = initial_states.detach().clone().requires_grad_()
+    activation = "silu" if silu_activation else None
+    out = causal_conv1d_fn(
+        x,
+        weight,
+        bias,
+        seq_idx=seq_idx,
+        initial_states=initial_states,
+        activation=activation,
+    )
+    out_ref = causal_conv1d_ref(
+        x_ref,
+        weight_ref,
+        bias_ref,
+        initial_states=initial_states_ref,
+        activation=activation,
+        seq_idx=seq_idx,
+    )
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+    g = torch.randn_like(out)
+    out.backward(g)
+    out_ref.backward(g)
+    print(f"dx max diff: {(x.grad - x_ref.grad).abs().max().item()}")
+    print(f"dweight max diff: {(weight.grad - weight_ref.grad).abs().max().item()}")
+    if bias is not None:
+        print(f"dbias max diff: {(bias.grad - bias_ref.grad).abs().max().item()}")
+    print(f"dinitial_states max diff: {(initial_states.grad - initial_states_ref.grad).abs().max().item()}")
+
+    assert torch.allclose(x.grad, x_ref.grad.to(dtype=itype), rtol=rtol, atol=atol)
+    assert torch.allclose(weight.grad, weight_ref.grad, rtol=rtolw, atol=atolw)
+    if bias is not None:
+        assert torch.allclose(bias.grad, bias_ref.grad, rtol=rtolw, atol=atolw)
+    assert torch.allclose(
+        initial_states.grad,
+        initial_states_ref.grad.to(dtype=itype),
+        rtol=rtol,
+        atol=atol,
+    )
+
 @pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
 # @pytest.mark.parametrize('itype', [torch.bfloat16])
 @pytest.mark.parametrize("silu_activation", [False, True])


### PR DESCRIPTION
`seq_idx` and `initial_states` were previously rejected when provided together. This PR adds support for combining them.

To test:
```
python -m pytest -q \
    tests/test_causal_conv1d.py::test_causal_conv1d_ref_varlen_initial_states \
    tests/test_causal_conv1d.py::test_causal_conv1d_varlen_initial_states
```