### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/causal_conv1d/__init__.py
+++ b/causal_conv1d/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.6.2.post1"
+__version__ = "1.7.0"
 
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_update


### PR DESCRIPTION
## Background / motivation

Prepare the package metadata and prebuilt-wheel release lookup for v1.7.0.

## What changed

- Set `causal_conv1d.__version__` to `1.7.0`.

## Details

- `setup.py` reads this value for package metadata and constructs release asset URLs with the `v1.7.0` tag.

## Tested

- `python -m compileall -q causal_conv1d/__init__.py` — passed
- Parsed `causal_conv1d/__init__.py` with Python's AST and asserted the version equals `1.7.0` — passed
- `git diff --check` — passed
